### PR TITLE
Add deploying all the private rule processors for MacOS

### DIFF
--- a/Guides/full-service-full-stack-docker-tazama.md
+++ b/Guides/full-service-full-stack-docker-tazama.md
@@ -82,7 +82,7 @@ TMS_PORT=5000
 NODE_TLS_REJECT_UNAUTHORIZED='0'
 ```
 
-### ./env/rule\*.env
+### ./env/rule*.env
 
 Using the `rule.env` file as a template, we want to create a separate rule.env file for each private rule processor. In VS Code, navigate to the `Full-Stack-Docker-Tazama/env` folder and open the `rule.env` file. In each separate `rule.env` file, update the following environment variables to match the rule number, and then save the file with that rule number in the filename:
 

--- a/Guides/full-service-full-stack-docker-tazama.md
+++ b/Guides/full-service-full-stack-docker-tazama.md
@@ -341,7 +341,26 @@ The steps 1 to 5 above must be performed for each private rule processor to depl
 
 ## Batch process alternative
 
-Instead of deploying all the private rule processors by hand, you can run the following batch file to automate the steps above for all the rule processors.
+Instead of deploying all the private rule processors by hand, you can run the one of the following batch scripts to automate the steps above for all the rule processors.
+
+### Microsoft Windows batch file
+
+For Windows download the Windows batch file `deploy-all-tazama-rule-processors.bat` file into your source code root folder from:
+
+<https://github.com/frmscoe/docs/blob/main/files/full-stack-docker-tazama/deploy-all-tazama-rule-processors.bat>
+
+From a Command Prompt, from the source code root folder, execute the batch file as follows:
+
+```
+deploy-all-tazama-rule-processors.bat "source-code-root-folder-path"
+```
+
+ - The `source-code-root-folder-path` is the full path to the location on your local machine where you have been cloning the GitHub repositories from.
+ - For example, the source code root folder path I have been using the compiled this guide is `D:\DevTools\GitHub`:
+
+ ![source-root](../images/full-stack-docker-tazama-source-root.png)
+
+### MacOS shell script
 
 For MacOS download the MacOS batch file into your source code root folder from [MacOS-deploy-all-tazama-rule-processors](../files/full-stack-docker-tazama/macos-deploy-all-tazama-rule-processors.sh).
 
@@ -359,20 +378,7 @@ chmod +x ./deploy-rule-processors.sh​
 # Then, follow the prompts in the terminal to complete the deployment process.
 ```
 
-For Windows download the Windows batch file `deploy-all-tazama-rule-processors.bat` file into your source code root folder from:
-
-<https://github.com/frmscoe/docs/blob/main/files/full-stack-docker-tazama/deploy-all-tazama-rule-processors.bat>
-
-From a Command Prompt, from the source code root folder, execute the batch file as follows:
-
-```
-deploy-all-tazama-rule-processors.bat "source-code-root-folder-path"
-```
-
- - The `source-code-root-folder-path` is the full path to the location on your local machine where you have been cloning the GitHub repositories from.
- - For example, the source code root folder path I have been using the compiled this guide is `D:\DevTools\GitHub`:
-
- ![source-root](../images/full-stack-docker-tazama-source-root.png)
+### Execution
 
 Depending on the performance of your local machine, this process may take quite a while. The batch process is divided into three parts:
 

--- a/Guides/full-service-full-stack-docker-tazama.md
+++ b/Guides/full-service-full-stack-docker-tazama.md
@@ -82,7 +82,7 @@ TMS_PORT=5000
 NODE_TLS_REJECT_UNAUTHORIZED='0'
 ```
 
-### ./env/rule*.env
+### ./env/rule\*.env
 
 Using the `rule.env` file as a template, we want to create a separate rule.env file for each private rule processor. In VS Code, navigate to the `Full-Stack-Docker-Tazama/env` folder and open the `rule.env` file. In each separate `rule.env` file, update the following environment variables to match the rule number, and then save the file with that rule number in the filename:
 
@@ -343,7 +343,23 @@ The steps 1 to 5 above must be performed for each private rule processor to depl
 
 Instead of deploying all the private rule processors by hand, you can run the following batch file to automate the steps above for all the rule processors.
 
-Download the Windows batch file `deploy-all-tazama-rule-processors.bat` file into your source code root folder from:
+For MacOS download the MacOS batch file into your source code root folder from [MacOS-deploy-all-tazama-rule-processors](../files/full-stack-docker-tazama/macos-deploy-all-tazama-rule-processors.sh).
+
+> **Note:** The source code root folder is the folder where you have been cloning the GitHub repositories from.
+
+From a Command Prompt, from the source code root folder, execute the following command:
+
+```shell
+# Grant execution rights to the script by running the following command in your terminal:
+chmod +x ./deploy-rule-processors.sh​
+
+# You can run the script with:
+./deploy-rule-processors.sh
+
+# Then, follow the prompts in the terminal to complete the deployment process.
+```
+
+For Windows download the Windows batch file `deploy-all-tazama-rule-processors.bat` file into your source code root folder from:
 
 <https://github.com/frmscoe/docs/blob/main/files/full-stack-docker-tazama/deploy-all-tazama-rule-processors.bat>
 

--- a/files/full-stack-docker-tazama/macos-deploy-all-tazama-rule-processors.sh
+++ b/files/full-stack-docker-tazama/macos-deploy-all-tazama-rule-processors.sh
@@ -1,0 +1,249 @@
+#!/bin/bash
+echo "Duplicating Rule Executer folder..."
+cp -R rule-executer rule-executer-001
+cp -R rule-executer rule-executer-002
+cp -R rule-executer rule-executer-003
+cp -R rule-executer rule-executer-004
+cp -R rule-executer rule-executer-006
+cp -R rule-executer rule-executer-007
+cp -R rule-executer rule-executer-008
+cp -R rule-executer rule-executer-010
+cp -R rule-executer rule-executer-011
+cp -R rule-executer rule-executer-016
+cp -R rule-executer rule-executer-017
+cp -R rule-executer rule-executer-018
+cp -R rule-executer rule-executer-020
+cp -R rule-executer rule-executer-021
+cp -R rule-executer rule-executer-024
+cp -R rule-executer rule-executer-025
+cp -R rule-executer rule-executer-026
+cp -R rule-executer rule-executer-027
+cp -R rule-executer rule-executer-028
+cp -R rule-executer rule-executer-030
+cp -R rule-executer rule-executer-044
+cp -R rule-executer rule-executer-045
+cp -R rule-executer rule-executer-048
+cp -R rule-executer rule-executer-054
+cp -R rule-executer rule-executer-063
+cp -R rule-executer rule-executer-074
+cp -R rule-executer rule-executer-075
+cp -R rule-executer rule-executer-076
+cp -R rule-executer rule-executer-078
+cp -R rule-executer rule-executer-083
+cp -R rule-executer rule-executer-084
+cp -R rule-executer rule-executer-090
+cp -R rule-executer rule-executer-091
+echo "Rule Executer folders duplicated."
+
+echo "Modifying rule-executer-001 files..."
+sed -i '' 's/rule-901@\^1.0.7/rule-001@latest/' rule-executer-001/package.json
+sed -i '' 's/901/001/' rule-executer-001/Dockerfile
+
+echo "Modifying rule-executer-002 files..."
+sed -i '' 's/rule-901@\^1.0.7/rule-002@latest/' rule-executer-002/package.json
+sed -i '' 's/901/002/' rule-executer-002/Dockerfile
+
+echo "Modifying rule-executer-003 files..."
+sed -i '' 's/rule-901@\^1.0.7/rule-003@latest/' rule-executer-003/package.json
+sed -i '' 's/901/003/' rule-executer-003/Dockerfile
+
+echo "Modifying rule-executer-004 files..."
+sed -i '' 's/rule-901@\^1.0.7/rule-004@latest/' rule-executer-004/package.json
+sed -i '' 's/901/004/' rule-executer-004/Dockerfile
+
+echo "Modifying rule-executer-006 files..."
+sed -i '' 's/rule-901@\^1.0.7/rule-006@latest/' rule-executer-006/package.json
+sed -i '' 's/901/006/' rule-executer-006/Dockerfile
+
+echo "Modifying rule-executer-007 files..."
+sed -i '' 's/rule-901@\^1.0.7/rule-007@latest/' rule-executer-007/package.json
+sed -i '' 's/901/007/' rule-executer-007/Dockerfile
+
+echo "Modifying rule-executer-008 files..."
+sed -i '' 's/rule-901@\^1.0.7/rule-008@latest/' rule-executer-008/package.json
+sed -i '' 's/901/008/' rule-executer-008/Dockerfile
+
+echo "Modifying rule-executer-010 files..."
+sed -i '' 's/rule-901@\^1.0.7/rule-010@latest/' rule-executer-010/package.json
+sed -i '' 's/901/010/' rule-executer-010/Dockerfile
+
+echo "Modifying rule-executer-011 files..."
+sed -i '' 's/rule-901@\^1.0.7/rule-011@latest/' rule-executer-011/package.json
+sed -i '' 's/901/011/' rule-executer-011/Dockerfile
+
+echo "Modifying rule-executer-016 files..."
+sed -i '' 's/rule-901@\^1.0.7/rule-016@latest/' rule-executer-016/package.json
+sed -i '' 's/901/016/' rule-executer-016/Dockerfile
+
+echo "Modifying rule-executer-017 files..."
+sed -i '' 's/rule-901@\^1.0.7/rule-017@latest/' rule-executer-017/package.json
+sed -i '' 's/901/017/' rule-executer-017/Dockerfile
+
+echo "Modifying rule-executer-018 files..."
+sed -i '' 's/rule-901@\^1.0.7/rule-018@latest/' rule-executer-018/package.json
+sed -i '' 's/901/018/' rule-executer-018/Dockerfile
+
+echo "Modifying rule-executer-020 files..."
+sed -i '' 's/rule-901@\^1.0.7/rule-020@latest/' rule-executer-020/package.json
+sed -i '' 's/901/020/' rule-executer-020/Dockerfile
+
+echo "Modifying rule-executer-021 files..."
+sed -i '' 's/rule-901@\^1.0.7/rule-021@latest/' rule-executer-021/package.json
+sed -i '' 's/901/021/' rule-executer-021/Dockerfile
+
+echo "Modifying rule-executer-024 files..."
+sed -i '' 's/rule-901@\^1.0.7/rule-024@latest/' rule-executer-024/package.json
+sed -i '' 's/901/024/' rule-executer-024/Dockerfile
+
+echo "Modifying rule-executer-025 files..."
+sed -i '' 's/rule-901@\^1.0.7/rule-025@latest/' rule-executer-025/package.json
+sed -i '' 's/901/025/' rule-executer-025/Dockerfile
+
+echo "Modifying rule-executer-026 files..."
+sed -i '' 's/rule-901@\^1.0.7/rule-026@latest/' rule-executer-026/package.json
+sed -i '' 's/901/026/' rule-executer-026/Dockerfile
+
+echo "Modifying rule-executer-027 files..."
+sed -i '' 's/rule-901@\^1.0.7/rule-027@latest/' rule-executer-027/package.json
+sed -i '' 's/901/027/' rule-executer-027/Dockerfile
+
+echo "Modifying rule-executer-028 files..."
+sed -i '' 's/rule-901@\^1.0.7/rule-028@latest/' rule-executer-028/package.json
+sed -i '' 's/901/028/' rule-executer-028/Dockerfile
+
+echo "Modifying rule-executer-030 files..."
+sed -i '' 's/rule-901@\^1.0.7/rule-030@latest/' rule-executer-030/package.json
+sed -i '' 's/901/030/' rule-executer-030/Dockerfile
+
+echo "Modifying rule-executer-044 files..."
+sed -i '' 's/rule-901@\^1.0.7/rule-044@latest/' rule-executer-044/package.json
+sed -i '' 's/901/044/' rule-executer-044/Dockerfile
+
+echo "Modifying rule-executer-045 files..."
+sed -i '' 's/rule-901@\^1.0.7/rule-045@latest/' rule-executer-045/package.json
+sed -i '' 's/901/045/' rule-executer-045/Dockerfile
+
+echo "Modifying rule-executer-048 files..."
+sed -i '' 's/rule-901@\^1.0.7/rule-048@latest/' rule-executer-048/package.json
+sed -i '' 's/901/048/' rule-executer-048/Dockerfile
+
+echo "Modifying rule-executer-054 files..."
+sed -i '' 's/rule-901@\^1.0.7/rule-054@latest/' rule-executer-054/package.json
+sed -i '' 's/901/054/' rule-executer-054/Dockerfile
+
+echo "Modifying rule-executer-063 files..."
+sed -i '' 's/rule-901@\^1.0.7/rule-063@latest/' rule-executer-063/package.json
+sed -i '' 's/901/063/' rule-executer-063/Dockerfile
+
+echo "Modifying rule-executer-074 files..."
+sed -i '' 's/rule-901@\^1.0.7/rule-074@latest/' rule-executer-074/package.json
+sed -i '' 's/901/074/' rule-executer-074/Dockerfile
+
+echo "Modifying rule-executer-075 files..."
+sed -i '' 's/rule-901@\^1.0.7/rule-075@latest/' rule-executer-075/package.json
+sed -i '' 's/901/075/' rule-executer-075/Dockerfile
+
+echo "Modifying rule-executer-076 files..."
+sed -i '' 's/rule-901@\^1.0.7/rule-076@latest/' rule-executer-076/package.json
+sed -i '' 's/901/076/' rule-executer-076/Dockerfile
+
+echo "Modifying rule-executer-078 files..."
+sed -i '' 's/rule-901@\^1.0.7/rule-078@latest/' rule-executer-078/package.json
+sed -i '' 's/901/078/' rule-executer-078/Dockerfile
+
+echo "Modifying rule-executer-083 files..."
+sed -i '' 's/rule-901@\^1.0.7/rule-083@latest/' rule-executer-083/package.json
+sed -i '' 's/901/083/' rule-executer-083/Dockerfile
+
+echo "Modifying rule-executer-084 files..."
+sed -i '' 's/rule-901@\^1.0.7/rule-084@latest/' rule-executer-084/package.json
+sed -i '' 's/901/084/' rule-executer-084/Dockerfile
+
+echo "Modifying rule-executer-090 files..."
+sed -i '' 's/rule-901@\^1.0.7/rule-090@latest/' rule-executer-090/package.json
+sed -i '' 's/901/090/' rule-executer-090/Dockerfile
+
+echo "Modifying rule-executer-091 files..."
+sed -i '' 's/rule-901@\^1.0.7/rule-091@latest/' rule-executer-091/package.json
+sed -i '' 's/901/091/' rule-executer-091/Dockerfile
+echo "Files modified."
+
+echo "Press any key to continue..."
+read -n 1
+
+echo "Building rule packages..."
+cd rule-executer-001 && npm install
+cd ../rule-executer-002 && npm install
+cd ../rule-executer-003 && npm install
+cd ../rule-executer-004 && npm install
+cd ../rule-executer-006 && npm install
+cd ../rule-executer-007 && npm install
+cd ../rule-executer-008 && npm install
+cd ../rule-executer-010 && npm install
+cd ../rule-executer-011 && npm install
+cd ../rule-executer-016 && npm install
+cd ../rule-executer-017 && npm install
+cd ../rule-executer-018 && npm install
+cd ../rule-executer-020 && npm install
+cd ../rule-executer-021 && npm install
+cd ../rule-executer-024 && npm install
+cd ../rule-executer-025 && npm install
+cd ../rule-executer-026 && npm install
+cd ../rule-executer-027 && npm install
+cd ../rule-executer-028 && npm install
+cd ../rule-executer-030 && npm install
+cd ../rule-executer-044 && npm install
+cd ../rule-executer-045 && npm install
+cd ../rule-executer-048 && npm install
+cd ../rule-executer-054 && npm install
+cd ../rule-executer-063 && npm install
+cd ../rule-executer-074 && npm install
+cd ../rule-executer-075 && npm install
+cd ../rule-executer-076 && npm install
+cd ../rule-executer-078 && npm install
+cd ../rule-executer-083 && npm install
+cd ../rule-executer-084 && npm install
+cd ../rule-executer-090 && npm install
+cd ../rule-executer-091 && npm install
+echo "Rule packages built."
+
+echo "Press any key to continue..."
+read -n 1
+
+echo "Deploying rule processors into Docker..."
+cd ../Full-Stack-Docker-Tazama
+docker compose up -d rule-001
+docker compose up -d rule-002
+docker compose up -d rule-003
+docker compose up -d rule-004
+docker compose up -d rule-006
+docker compose up -d rule-007
+docker compose up -d rule-008
+docker compose up -d rule-010
+docker compose up -d rule-011
+docker compose up -d rule-016
+docker compose up -d rule-017
+docker compose up -d rule-018
+docker compose up -d rule-020
+docker compose up -d rule-021
+docker compose up -d rule-024
+docker compose up -d rule-025
+docker compose up -d rule-026
+docker compose up -d rule-027
+docker compose up -d rule-028
+docker compose up -d rule-030
+docker compose up -d rule-044
+docker compose up -d rule-045
+docker compose up -d rule-048
+docker compose up -d rule-054
+docker compose up -d rule-063
+docker compose up -d rule-074
+docker compose up -d rule-075
+docker compose up -d rule-076
+docker compose up -d rule-078
+docker compose up -d rule-083
+docker compose up -d rule-084
+docker compose up -d rule-090
+docker compose up -d rule-091
+
+echo "Deployment complete."

--- a/files/full-stack-docker-tazama/macos-deploy-all-tazama-rule-processors.sh
+++ b/files/full-stack-docker-tazama/macos-deploy-all-tazama-rule-processors.sh
@@ -36,135 +36,135 @@ cp -R rule-executer rule-executer-091
 echo "Rule Executer folders duplicated."
 
 echo "Modifying rule-executer-001 files..."
-sed -i '' 's/rule-901@\^1.0.7/rule-001@latest/' rule-executer-001/package.json
+sed -i '' 's/rule-901@latest/rule-001@latest/' rule-executer-001/package.json
 sed -i '' 's/901/001/' rule-executer-001/Dockerfile
 
 echo "Modifying rule-executer-002 files..."
-sed -i '' 's/rule-901@\^1.0.7/rule-002@latest/' rule-executer-002/package.json
+sed -i '' 's/rule-901@latest/rule-002@latest/' rule-executer-002/package.json
 sed -i '' 's/901/002/' rule-executer-002/Dockerfile
 
 echo "Modifying rule-executer-003 files..."
-sed -i '' 's/rule-901@\^1.0.7/rule-003@latest/' rule-executer-003/package.json
+sed -i '' 's/rule-901@latest/rule-003@latest/' rule-executer-003/package.json
 sed -i '' 's/901/003/' rule-executer-003/Dockerfile
 
 echo "Modifying rule-executer-004 files..."
-sed -i '' 's/rule-901@\^1.0.7/rule-004@latest/' rule-executer-004/package.json
+sed -i '' 's/rule-901@latest/rule-004@latest/' rule-executer-004/package.json
 sed -i '' 's/901/004/' rule-executer-004/Dockerfile
 
 echo "Modifying rule-executer-006 files..."
-sed -i '' 's/rule-901@\^1.0.7/rule-006@latest/' rule-executer-006/package.json
+sed -i '' 's/rule-901@latest/rule-006@latest/' rule-executer-006/package.json
 sed -i '' 's/901/006/' rule-executer-006/Dockerfile
 
 echo "Modifying rule-executer-007 files..."
-sed -i '' 's/rule-901@\^1.0.7/rule-007@latest/' rule-executer-007/package.json
+sed -i '' 's/rule-901@latest/rule-007@latest/' rule-executer-007/package.json
 sed -i '' 's/901/007/' rule-executer-007/Dockerfile
 
 echo "Modifying rule-executer-008 files..."
-sed -i '' 's/rule-901@\^1.0.7/rule-008@latest/' rule-executer-008/package.json
+sed -i '' 's/rule-901@latest/rule-008@latest/' rule-executer-008/package.json
 sed -i '' 's/901/008/' rule-executer-008/Dockerfile
 
 echo "Modifying rule-executer-010 files..."
-sed -i '' 's/rule-901@\^1.0.7/rule-010@latest/' rule-executer-010/package.json
+sed -i '' 's/rule-901@latest/rule-010@latest/' rule-executer-010/package.json
 sed -i '' 's/901/010/' rule-executer-010/Dockerfile
 
 echo "Modifying rule-executer-011 files..."
-sed -i '' 's/rule-901@\^1.0.7/rule-011@latest/' rule-executer-011/package.json
+sed -i '' 's/rule-901@latest/rule-011@latest/' rule-executer-011/package.json
 sed -i '' 's/901/011/' rule-executer-011/Dockerfile
 
 echo "Modifying rule-executer-016 files..."
-sed -i '' 's/rule-901@\^1.0.7/rule-016@latest/' rule-executer-016/package.json
+sed -i '' 's/rule-901@latest/rule-016@latest/' rule-executer-016/package.json
 sed -i '' 's/901/016/' rule-executer-016/Dockerfile
 
 echo "Modifying rule-executer-017 files..."
-sed -i '' 's/rule-901@\^1.0.7/rule-017@latest/' rule-executer-017/package.json
+sed -i '' 's/rule-901@latest/rule-017@latest/' rule-executer-017/package.json
 sed -i '' 's/901/017/' rule-executer-017/Dockerfile
 
 echo "Modifying rule-executer-018 files..."
-sed -i '' 's/rule-901@\^1.0.7/rule-018@latest/' rule-executer-018/package.json
+sed -i '' 's/rule-901@latest/rule-018@latest/' rule-executer-018/package.json
 sed -i '' 's/901/018/' rule-executer-018/Dockerfile
 
 echo "Modifying rule-executer-020 files..."
-sed -i '' 's/rule-901@\^1.0.7/rule-020@latest/' rule-executer-020/package.json
+sed -i '' 's/rule-901@latest/rule-020@latest/' rule-executer-020/package.json
 sed -i '' 's/901/020/' rule-executer-020/Dockerfile
 
 echo "Modifying rule-executer-021 files..."
-sed -i '' 's/rule-901@\^1.0.7/rule-021@latest/' rule-executer-021/package.json
+sed -i '' 's/rule-901@latest/rule-021@latest/' rule-executer-021/package.json
 sed -i '' 's/901/021/' rule-executer-021/Dockerfile
 
 echo "Modifying rule-executer-024 files..."
-sed -i '' 's/rule-901@\^1.0.7/rule-024@latest/' rule-executer-024/package.json
+sed -i '' 's/rule-901@latest/rule-024@latest/' rule-executer-024/package.json
 sed -i '' 's/901/024/' rule-executer-024/Dockerfile
 
 echo "Modifying rule-executer-025 files..."
-sed -i '' 's/rule-901@\^1.0.7/rule-025@latest/' rule-executer-025/package.json
+sed -i '' 's/rule-901@latest/rule-025@latest/' rule-executer-025/package.json
 sed -i '' 's/901/025/' rule-executer-025/Dockerfile
 
 echo "Modifying rule-executer-026 files..."
-sed -i '' 's/rule-901@\^1.0.7/rule-026@latest/' rule-executer-026/package.json
+sed -i '' 's/rule-901@latest/rule-026@latest/' rule-executer-026/package.json
 sed -i '' 's/901/026/' rule-executer-026/Dockerfile
 
 echo "Modifying rule-executer-027 files..."
-sed -i '' 's/rule-901@\^1.0.7/rule-027@latest/' rule-executer-027/package.json
+sed -i '' 's/rule-901@latest/rule-027@latest/' rule-executer-027/package.json
 sed -i '' 's/901/027/' rule-executer-027/Dockerfile
 
 echo "Modifying rule-executer-028 files..."
-sed -i '' 's/rule-901@\^1.0.7/rule-028@latest/' rule-executer-028/package.json
+sed -i '' 's/rule-901@latest/rule-028@latest/' rule-executer-028/package.json
 sed -i '' 's/901/028/' rule-executer-028/Dockerfile
 
 echo "Modifying rule-executer-030 files..."
-sed -i '' 's/rule-901@\^1.0.7/rule-030@latest/' rule-executer-030/package.json
+sed -i '' 's/rule-901@latest/rule-030@latest/' rule-executer-030/package.json
 sed -i '' 's/901/030/' rule-executer-030/Dockerfile
 
 echo "Modifying rule-executer-044 files..."
-sed -i '' 's/rule-901@\^1.0.7/rule-044@latest/' rule-executer-044/package.json
+sed -i '' 's/rule-901@latest/rule-044@latest/' rule-executer-044/package.json
 sed -i '' 's/901/044/' rule-executer-044/Dockerfile
 
 echo "Modifying rule-executer-045 files..."
-sed -i '' 's/rule-901@\^1.0.7/rule-045@latest/' rule-executer-045/package.json
+sed -i '' 's/rule-901@latest/rule-045@latest/' rule-executer-045/package.json
 sed -i '' 's/901/045/' rule-executer-045/Dockerfile
 
 echo "Modifying rule-executer-048 files..."
-sed -i '' 's/rule-901@\^1.0.7/rule-048@latest/' rule-executer-048/package.json
+sed -i '' 's/rule-901@latest/rule-048@latest/' rule-executer-048/package.json
 sed -i '' 's/901/048/' rule-executer-048/Dockerfile
 
 echo "Modifying rule-executer-054 files..."
-sed -i '' 's/rule-901@\^1.0.7/rule-054@latest/' rule-executer-054/package.json
+sed -i '' 's/rule-901@latest/rule-054@latest/' rule-executer-054/package.json
 sed -i '' 's/901/054/' rule-executer-054/Dockerfile
 
 echo "Modifying rule-executer-063 files..."
-sed -i '' 's/rule-901@\^1.0.7/rule-063@latest/' rule-executer-063/package.json
+sed -i '' 's/rule-901@latest/rule-063@latest/' rule-executer-063/package.json
 sed -i '' 's/901/063/' rule-executer-063/Dockerfile
 
 echo "Modifying rule-executer-074 files..."
-sed -i '' 's/rule-901@\^1.0.7/rule-074@latest/' rule-executer-074/package.json
+sed -i '' 's/rule-901@latest/rule-074@latest/' rule-executer-074/package.json
 sed -i '' 's/901/074/' rule-executer-074/Dockerfile
 
 echo "Modifying rule-executer-075 files..."
-sed -i '' 's/rule-901@\^1.0.7/rule-075@latest/' rule-executer-075/package.json
+sed -i '' 's/rule-901@latest/rule-075@latest/' rule-executer-075/package.json
 sed -i '' 's/901/075/' rule-executer-075/Dockerfile
 
 echo "Modifying rule-executer-076 files..."
-sed -i '' 's/rule-901@\^1.0.7/rule-076@latest/' rule-executer-076/package.json
+sed -i '' 's/rule-901@latest/rule-076@latest/' rule-executer-076/package.json
 sed -i '' 's/901/076/' rule-executer-076/Dockerfile
 
 echo "Modifying rule-executer-078 files..."
-sed -i '' 's/rule-901@\^1.0.7/rule-078@latest/' rule-executer-078/package.json
+sed -i '' 's/rule-901@latest/rule-078@latest/' rule-executer-078/package.json
 sed -i '' 's/901/078/' rule-executer-078/Dockerfile
 
 echo "Modifying rule-executer-083 files..."
-sed -i '' 's/rule-901@\^1.0.7/rule-083@latest/' rule-executer-083/package.json
+sed -i '' 's/rule-901@latest/rule-083@latest/' rule-executer-083/package.json
 sed -i '' 's/901/083/' rule-executer-083/Dockerfile
 
 echo "Modifying rule-executer-084 files..."
-sed -i '' 's/rule-901@\^1.0.7/rule-084@latest/' rule-executer-084/package.json
+sed -i '' 's/rule-901@latest/rule-084@latest/' rule-executer-084/package.json
 sed -i '' 's/901/084/' rule-executer-084/Dockerfile
 
 echo "Modifying rule-executer-090 files..."
-sed -i '' 's/rule-901@\^1.0.7/rule-090@latest/' rule-executer-090/package.json
+sed -i '' 's/rule-901@latest/rule-090@latest/' rule-executer-090/package.json
 sed -i '' 's/901/090/' rule-executer-090/Dockerfile
 
 echo "Modifying rule-executer-091 files..."
-sed -i '' 's/rule-901@\^1.0.7/rule-091@latest/' rule-executer-091/package.json
+sed -i '' 's/rule-901@latest/rule-091@latest/' rule-executer-091/package.json
 sed -i '' 's/901/091/' rule-executer-091/Dockerfile
 echo "Files modified."
 


### PR DESCRIPTION
This PR introduces instructions and scripts that allow for the deployment of all private rule processors on MacOS.

Changes:
Added support for deploying all private rule processors on MacOS.

Impact:
This will enable MacOS users to deploy all private rule processors, enhancing the usability of our system for MacOS environments.