### PR TITLE
Add release simple v1 workflow process in docs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@
 # Then push the release tag created above by running "git push origin vx.x.x"
 # The tag will be set on the release page on github with changes made
 
-name: Createa a New Release
+name: Create a New Release
 
 on:
   push:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,37 @@
+# SPDX-License-Identifier: Apache-2.0
+
+# Please do not attempt to edit this flow without the direct consent from the Tazama team. This file is managed centrally.
+
+# This workflow should only be run when while on the main branch
+# Create a tag locally using "git tag vx.x.x" supposed to match latest version in changelog.md
+# Then push the release tag created above by running "git push origin vx.x.x"
+# The tag will be set on the release page on github with changes made
+
+name: Createa a New Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    name: Release pushed tag
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Create release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          tag: ${{ github.ref_name }}
+        run: |
+          gh release create "$tag" \
+              --repo="$GITHUB_REPOSITORY" \
+              --title="${tag#v}" \
+              --generate-notes
+
+# Usage (while on main branch)
+# git tag v1.0.0
+# git push origin v1.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: Apache-2.0
+# Docs
+
+## v1.0
+
+## v1.0.0 (June 14th, 2024)
+
+* Release first version of docs.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 ## v1.0
 
+## v1.1.0 (future date, 2024)
+
+* Next change summary here
+
 ## v1.0.0 (June 14th, 2024)
 
 * Release first version of docs.

--- a/VERSION
+++ b/VERSION
@@ -1,0 +1,3 @@
+# SPDX-License-Identifier: Apache-2.0
+
+v1.0.0


### PR DESCRIPTION
## What did we change?
- Added a release workflow process
- Includes a PR template

## Why are we doing this?
- This will be our initial version of the release process. There's room for improvement with the adoption of convention commits but this is a good first step to see us automate our release process

## How was it tested?
- [x] Locally
- [x] Development Environment
- [ ] Not needed, changes very basic