### PR TITLE
240725 update docs

### DIFF
--- a/Product/configuration-management.md
+++ b/Product/configuration-management.md
@@ -11,7 +11,7 @@
     - [Rule configuration metadata](#rule-configuration-metadata)
     - [The configuration object - parameters](#the-configuration-object---parameters)
     - [The configuration object - exit conditions](#the-configuration-object---exit-conditions)
-      - [The `.err` exit condition](#the-err-exit-condition)
+      - [The `.err` condition](#the-err-condition)
     - [The configuration object - rule results](#the-configuration-object---rule-results)
       - [Rule results - banded results](#rule-results---banded-results)
       - [Rule results - cased results](#rule-results---cased-results)
@@ -233,7 +233,7 @@ Each exit condition contains the same attributes:
 | `subRuleRef` | Every rule processor is capable of reporting a number of different outcomes, but only a single outcome from the complete set is ultimately delivered to the typology processor. Each outcome is defined by a unique sub-rule reference identifier to differentiate the delivered outcome from the others and also to allow the typology processor to apply a unique weighting to that specific outcome.<br><br> By convention, the exit condition sub-rule references are prefaced with an 'x'. |
 | `reason` | The reason provides a human-readable description of the result that accompanies the rule result to the eventual over-all evaluation result. Reason descriptions will be refined during future enhancements[^1] |
 
-#### The `.err` exit condition
+#### The `.err` condition
 
 All rule processors are encoded with an error condition outcome that accounts for exceptions that do not fall into any of the exit conditions above, or the rule results below. These error conditions reflect a fatal error that occurred during the execution of the rule processor, such as, for example, if the database is inaccessible or if some expected data dependency had not been met due to an error during data ingestion or transformation.
 

--- a/Product/transaction-monitoring-service-api.md
+++ b/Product/transaction-monitoring-service-api.md
@@ -32,10 +32,10 @@ By default, Tazama is set up to evaluate four transactions composed into a two-s
 
 With Tazama and the TMS API up and running, you can send the messages to their respective endpoints:
 
- - `host:port/execute` - receives a [pain.001 message](https://www.iso20022.org/standardsrepository/type/pain.001.001.11) to initiate a **quote request**
- - `host:port/quoteReply` - receives a [pain.013 message](https://www.iso20022.org/standardsrepository/type/pain.013.001.08) for the **quote response**
- - `host:port/transfer` - receives a [pacs.008 message](https://www.iso20022.org/standardsrepository/type/pacs.008.001.09) to initiate a **transfer request**
- - `host:port/transfer-response` - receives a [pacs.002 message](https://www.iso20022.org/standardsrepository/type/pacs.002.001.11) for the **transfer response**
+ - `host:port/v1/evaluate/iso20022/pain.001.001.13` - receives a [pain.001 message](https://www.iso20022.org/standardsrepository/type/pain.001.001.11) to initiate a **quote request**
+ - `host:port/v1/evaluate/iso20022/pain.013.001.09` - receives a [pain.013 message](https://www.iso20022.org/standardsrepository/type/pain.013.001.08) for the **quote response**
+ - `host:port/tv1/evaluate/iso20022/pacs.008.001.10` - receives a [pacs.008 message](https://www.iso20022.org/standardsrepository/type/pacs.008.001.09) to initiate a **transfer request**
+ - `host:port/v1/evaluate/iso20022/pacs.002.001.12` - receives a [pacs.002 message](https://www.iso20022.org/standardsrepository/type/pacs.002.001.11) for the **transfer response**
 
 The TMS API follows the OpenAPI specification and each incoming message is validated using a Swagger document to ensure that the message meets the requirements to be ISO 20022 compliant, and also that the information that is necessary for a successful evaluation is provided.
 


### PR DESCRIPTION
# SPDX-License-Identifier: Apache-2.0

## What did we change?
1 Update to .err terminology to remove reference to `exit` condition
2 Update ISO20022 message endpoint names

## Why are we doing this?
1 To clarify `exit conditions` and `.err conditions`
2 To align documentation with recent changes to the API

## How was it tested?
- [ ] Locally
- [ ] Development Environment
- [X] Not needed, changes very basic
- [ ] Husky successfully run
- [ ] Unit tests passing and Documentation done