### PR TITLE
20240806 yaml docs

### DIFF
--- a/files/full-stack-docker-tazama/docker-compose.yaml
+++ b/files/full-stack-docker-tazama/docker-compose.yaml
@@ -8,7 +8,7 @@ services:
 
   # DATABASE
   arango:
-    image: "arangodb/arangodb:latest"
+    image: "arangodb/arangodb:l3.11.10.1"
     environment:
       - ARANGO_NO_AUTH=1
     command:

--- a/files/full-stack-docker-tazama/docker-compose.yaml
+++ b/files/full-stack-docker-tazama/docker-compose.yaml
@@ -8,7 +8,7 @@ services:
 
   # DATABASE
   arango:
-    image: "arangodb/arangodb:l3.11.10.1"
+    image: "arangodb/arangodb:3.11.10.1"
     environment:
       - ARANGO_NO_AUTH=1
     command:


### PR DESCRIPTION
# SPDX-License-Identifier: Apache-2.0

## What did we change?

docs/files/full-stack-docker-tazama/docker-compose.yaml arango DB version number 3.11.10.1

## Why are we doing this?

Full service deployment failing when following the instructions in the guide (post release 2.0)

## How was it tested?
- [x] Locally
- [ ] Development Environment
- [ ] Not needed, changes very basic
- [ ] Husky successfully run
- [ ] Unit tests passing and Documentation done