### PR TITLE
docs: Use working Arango version in docker compose file

### DIFF
--- a/files/full-stack-docker-tazama/docker-compose.yaml
+++ b/files/full-stack-docker-tazama/docker-compose.yaml
@@ -8,7 +8,7 @@ services:
 
   # DATABASE
   arango:
-    image: "arangodb/arangodb:latest"
+    image: "arangodb/arangodb:3.11.10.1"
     environment:
       - ARANGO_NO_AUTH=1
     command:


### PR DESCRIPTION
# SPDX-License-Identifier: Apache-2.0

## What did we change?
Use working Arango version in docker compose file


## How was it tested?
- [x] Locally
- [x] Development Environment
- [ ] Not needed, changes very basic
- [ ] Husky successfully run
- [ ] Unit tests passing and Documentation done