### PR TITLE
fix: add header to guide

### DIFF
--- a/Guides/drawio-guide.md
+++ b/Guides/drawio-guide.md
@@ -1,5 +1,8 @@
 <!-- SPDX-License-Identifier: Apache-2.0 -->
 
+## Guide for including diagrams in markdown files <!-- omit in toc -->
+
+
 - [Introduction](#introduction)
 - [Tazama Template](#tazama-template)
 - [Create and Update diagrams in draw.io](#create-and-update-diagrams-in-drawio)


### PR DESCRIPTION
# SPDX-License-Identifier: Apache-2.0

## What did we change?

Added a heading to the top of the page

## Why are we doing this?

Looks better

## How was it tested?
- [x ] Locally
- [ ] Development Environment
- [ ] Not needed, changes very basic
- [ ] Husky successfully run
- [ ] Unit tests passing and Documentation done