### PR TITLE
docs: Update full-service-full-stack-docker-tazama.md

### DIFF
--- a/Guides/full-service-full-stack-docker-tazama.md
+++ b/Guides/full-service-full-stack-docker-tazama.md
@@ -329,8 +329,16 @@ To skip ahead to the batch process, click: [batch process alternative](#batch-pr
 
 Navigate one folder up to your source code folder and copy the entire `rule-executer` folder to a new folder called `rule-executer-001`:
 
+This command is for users on windows
+
 ```
 xcopy rule-executer rule-executer-001 /E /I /H
+```
+
+MacOs and Linux users 
+
+```
+cp -R rule-executer rule-executer-001
 ```
 
 **Output:**


### PR DESCRIPTION
# SPDX-License-Identifier: Apache-2.0

## What did we change?
Add linux. / macOS command for copying the rule-executer into a rule

## How was it tested?
- [ ] Locally
- [x] Development Environment
- [ ] Not needed, changes very basic
- [ ] Husky successfully run
- [ ] Unit tests passing and Documentation done