### PR TITLE
docs: refresh product docs for EFRuP

### DIFF
--- a/Product/configuration-management.md
+++ b/Product/configuration-management.md
@@ -831,13 +831,7 @@ Given a version number **MAJOR.MINOR.PATCH (99.999.9999)**, increment the:
 
 Every rule processor, typology processor and transaction aggregation and decisioning processor (TADProc) is guided by its own configuration document. The specific version of a configuration document that is required to operate a processor is defined in the network map when the evaluation routing is specified. When a processor receives an instruction from its predecessor in the evaluation flow, the processor checks the network map to determine which configuration document and version to use to perform its tasks.
 
-When a new version of a configuration document is required, the updated version must be deployed to the appropriate configuration collection in the configuration database:
-
-| **Collection name** | **Processor Type** |
-| --- | --- |
-| `ruleConfiguration` | [Rule processor overview - rule config](/product/rule-processor-overview-rule-config.md) |
-| `typologyConfiguration` | [Typologies](/product/typology-processing.md) |
-
+When a new version of a configuration document is required, the updated version must be deployed to the appropriate configuration collection in the configuration database.
 
 Configuration documents can be posted to the appropriate collection via the ArangoDB API, either in bulk or one-by-one. When posting a new configuration for an existing processor, the database will not allow a user to submit a configuration for an "id" and "cfg" combination that already exists in the database: a new configuration must always be assigned a unique configuration version.
 

--- a/Product/configuration-management.md
+++ b/Product/configuration-management.md
@@ -10,7 +10,7 @@
     - [Rule configuration metadata](#rule-configuration-metadata)
     - [The configuration object - parameters](#the-configuration-object---parameters)
     - [The configuration object - exit conditions](#the-configuration-object---exit-conditions)
-      - [The `.err` condition](#the-err-condition)
+      - [The `".err"` condition](#the-err-condition)
     - [The configuration object - rule results](#the-configuration-object---rule-results)
       - [Rule results - banded results](#rule-results---banded-results)
       - [Rule results - cased results](#rule-results---cased-results)
@@ -199,7 +199,7 @@ If a rule processor does not use any parameters, the parameters object may eithe
 
 A rule processor's exit conditions ensure that a rule processor is always able to produce a result, even if the rule processor is unable to reach a definitive, deterministic outcome. Exit conditions account for non-deterministic exceptions in the rule processor's behavior. The exit conditions are coded into the rule processor and each exit condition must be provided in the configuration for the rule processor to deliver a successful outcome. If any of the exit conditions are missing, the rule processor will still deliver a result, but it will be error outcome complaining about the missing exit condition related to the specific exit condition code.
 
-By convention, exit condition codes are prefaced with an 'x' to differentiate them from regular rule results that have no prefix.
+By convention, exit condition codes are prefaced with an "x" to differentiate them from regular rule results that have no prefix.
 
 From a configuration perspective, the only real purpose for including the exit conditions in the configuration file is to accommodate implementation-specific and user-defined descriptions for the exit conditions, and, in a future release, accommodate multi-language support.
 
@@ -240,14 +240,14 @@ Each exit condition contains the same attributes:
 
 | **Attribute** | **Description** |
 | --- | --- |
-| `subRuleRef` | Every rule processor is capable of reporting a number of different outcomes, but only a single outcome from the complete set is ultimately delivered to the typology processor. Each outcome is defined by a unique sub-rule reference identifier to differentiate the delivered outcome from the others and also to allow the typology processor to apply a unique weighting to that specific outcome.<br><br> By convention, the exit condition sub-rule references are prefaced with an 'x'. |
+| `subRuleRef` | Every rule processor is capable of reporting a number of different outcomes, but only a single outcome from the complete set is ultimately delivered to the typology processor. Each outcome is defined by a unique sub-rule reference identifier to differentiate the delivered outcome from the others and also to allow the typology processor to apply a unique weighting to that specific outcome.<br><br> By convention, the exit condition sub-rule references are prefaced with an "x". |
 | `reason` | The reason provides a human-readable description of the result that accompanies the rule result to the eventual over-all evaluation result. Reason descriptions will be refined during future enhancements[^1] |
 
-#### The `.err` condition
+#### The `".err"` condition
 
 All rule processors are encoded with an error condition outcome that accounts for exceptions that do not fall into any of the exit conditions above, or the rule results below. These error conditions reflect a fatal error that occurred during the execution of the rule processor, such as, for example, if the database is inaccessible or if some expected data dependency had not been met due to an error during data ingestion or transformation.
 
-Rule processor error conditions are too numerous and diverse to explicitly define, and their definition is not required for the rule configuration anyway. The error conditions are handled exclusively in the rule code; however the error condition outcome will still be produced as a rule result to ensure continuity and end-to-end robustness in the system. If an error occurs, a rule processor will deliver a rule result with a very unique `.err` sub-rule reference and with a specific reason that describes the error. In rare instances, where an error condition was not anticipated during development, the reason might be a generic `Unhandled rule result outcome` message.
+Rule processor error conditions are too numerous and diverse to explicitly define, and their definition is not required for the rule configuration anyway. The error conditions are handled exclusively in the rule code; however the error condition outcome will still be produced as a rule result to ensure continuity and end-to-end robustness in the system. If an error occurs, a rule processor will deliver a rule result with a very unique `".err"` sub-rule reference and with a specific reason that describes the error. In rare instances, where an error condition was not anticipated during development, the reason might be a generic `Unhandled rule result outcome` message.
 
 ### The configuration object - rule results
 
@@ -263,7 +263,7 @@ While the parameters and exit conditions may be optional for a specific rule pro
 
 The rule processor's core purpose is to produce a definitive deterministic result based on its programmed behavioral analysis of historical data. The rule configuration defines the bands or values for which rule results can be provided.
 
-> [!WARNING] It is extremely important that the configuration of a rule processor does not leave any gaps in the results, whether banded or cased. Every possible outcome of a rule result must be accounted for, otherwise the rule processor may deliver a result that the typology processor cannot interpret. In the event that a rule processor result misses the configured results, the rule processor will issue an error (`.err`) result with a reason description of `Value provided undefined, so cannot determine rule outcome`.
+> [!WARNING] It is extremely important that the configuration of a rule processor does not leave any gaps in the results, whether banded or cased. Every possible outcome of a rule result must be accounted for, otherwise the rule processor may deliver a result that the typology processor cannot interpret. In the event that a rule processor result misses the configured results, the rule processor will issue an error (`".err"`) result with a reason description of `Value provided undefined, so cannot determine rule outcome`.
 
 #### Rule results - banded results
 
@@ -443,13 +443,13 @@ The `wghts` object is an array that contains the sub-rule references and the ass
 
 ***Every. Possible. Outcome.***
 
-All the possible outcomes from the rule processors are encapsulated in each rule's configuration, with the exception of the `.err` outcome that is not listed in the rule configuration because the conditions and descriptions are built into the rule processor itself. When composing the typology configuration, the user must remember to include the `.err` outcome, but the rest of the rule results (exit conditions and banded/cased results) can be directly reconciled with the elements in the `rules` object.
+All the possible outcomes from the rule processors are encapsulated in each rule's configuration, with the exception of the `".err"` outcome that is not listed in the rule configuration because the conditions and descriptions are built into the rule processor itself. When composing the typology configuration, the user must remember to include the `".err"` outcome, but the rest of the rule results (exit conditions and banded/cased results) can be directly reconciled with the elements in the `rules` object.
 
 **What does "every possible outcome" mean?**
 
 A rule processor must always produce a result, and only ever a single result from a number of possible results. The rule result will always fall into one of the following categories: error, exit or band/case. Results across all the categories are mutually exclusive and there can be only one result regardless of the category. Results are uniquely identified via the `subRuleRef` attribute:
 
-*   ".err" is reserved for the error condition, of which there will only ever be one;
+*   `".err"` is reserved for the error condition, of which there will only ever be one;
     
 *   exit conditions are prefaced with an ".x" and there may be many;
     

--- a/Product/event-director.md
+++ b/Product/event-director.md
@@ -18,7 +18,6 @@
 
 The foundation of the Tazama Transaction Monitoring service is its ability to evaluate incoming transactions for financial crime behaviors through the execution of a number of conditional statements (rules) that are then combined into typologies that describe the nature of the financial crime that the system is trying to detect. 
 
-
 The Event Director is responsible for determining which typologies a transaction must be submitted to for the transaction to be evaluated. As part of this process, the Event Director determines which rules must receive the transaction and then which typologies are to be scored. The Event Director then routes the transaction to the individual rule processors.
 
 ## Event Director Context
@@ -98,7 +97,7 @@ The pruned network sub-map will accompany the transaction message to the rule pr
 
 ### 2.4. De-duplicate Rules
 
-A single rule could be used to evaluate more than one typology. One of the primary advantages and reasons for the config-driven approach is to be able to minimize the number of times that a specific rule has to be executed. To achieve this objective, the Event Director will draft a list of all the rules in the network map and then eliminate duplicate rules from the list (the “Highlander” principle).
+A single rule could be used to evaluate more than one typology. One of the primary advantages and reasons for the config-driven approach is to be able to minimize the number of times that a specific rule has to be executed. To achieve this objective, the Event Director will draft a list of all the rules in the network map and then eliminate duplicate rules from the list (the 'Highlander' principle).
 
 Each rule in the network map can be uniquely described by the combination of the following attributes:
 

--- a/Product/event-director.md
+++ b/Product/event-director.md
@@ -97,7 +97,7 @@ The pruned network sub-map will accompany the transaction message to the rule pr
 
 ### 2.4. De-duplicate Rules
 
-A single rule could be used to evaluate more than one typology. One of the primary advantages and reasons for the config-driven approach is to be able to minimize the number of times that a specific rule has to be executed. To achieve this objective, the Event Director will draft a list of all the rules in the network map and then eliminate duplicate rules from the list (the 'Highlander' principle).
+A single rule could be used to evaluate more than one typology. One of the primary advantages and reasons for the config-driven approach is to be able to minimize the number of times that a specific rule has to be executed. To achieve this objective, the Event Director will draft a list of all the rules in the network map and then eliminate duplicate rules from the list (the "Highlander" principle).
 
 Each rule in the network map can be uniquely described by the combination of the following attributes:
 

--- a/Product/event-flow-rule-processor.md
+++ b/Product/event-flow-rule-processor.md
@@ -15,7 +15,7 @@
 
 The event flow rule processor (EFRuP) is a special rule processor that operates alongside all the other rule processors and enables operational control over the normal Tazama system functioning, for example, to be able to block a customer from transacting from any account or to override an interdiction and allow a transaction where it would otherwise have been blocked.
 
-The EFRuP can be configured to block or allow a transaction based on the evaluation of conditions against one of the transaction attributes. There are two types of conditions that can control event flow in the Tazama system, that can be created on a debtor or creditor: 
+The EFRuP can be configured to block or allow a transaction based on the evaluation of conditions against one of the transaction attributes. There are two types of conditions that can control event flow in the Tazama system. These conditions can be created on a debtor or creditor: 
 1.	Blocking conditions
     - non-overridable-block conditions (red)
     - overridable-block conditions (amber)
@@ -207,6 +207,10 @@ sequenceDiagram
 If a typology score is equal to or greater than the threshold value and there is an override in place, the Typology Processor will not trigger an interdiction workflow to instruct the client system to block the transaction event.
 
 **Note** The event flow rule processor result does not have a weight `wght` and will not be added to the typology score. 
+
+If the event flow processor is applicable to a typology, the EFRuP rule must be added to the list of rules in the typology configuration and EFRuP `"flowProcessor": "EFRuP@1.0.0"` will be added to the workflow object.
+
+`flowProcessor` may be omitted from the workflow object and the rules list in which case a particular typology is not affected by EFRuP results.
  
 **Sample output**
 

--- a/Product/event-flow-rule-processor.md
+++ b/Product/event-flow-rule-processor.md
@@ -15,7 +15,7 @@
 
 The event flow rule processor (EFRuP) is a special rule processor that operates alongside all the other rule processors and enables operational control over the normal Tazama system functioning, for example, to be able to block a customer from transacting from any account or to override an interdiction and allow a transaction where it would otherwise have been blocked.
 
-The EFRup can be configured to block or allow a transaction based on the evaluation of conditions against one of the transaction attributes. There are two types of conditions that can control event flow in the Tazama system that can be created on a debtor or creditor: 
+The EFRuP can be configured to block or allow a transaction based on the evaluation of conditions against one of the transaction attributes. There are two types of conditions that can control event flow in the Tazama system, that can be created on a debtor or creditor: 
 1.	Blocking conditions
     - non-overridable-block conditions (red)
     - overridable-block conditions (amber)
@@ -205,8 +205,6 @@ sequenceDiagram
 #### Typology processor
 
 If a typology score is equal to or greater than the threshold value and there is an override in place, the Typology Processor will not trigger an interdiction workflow to instruct the client system to block the transaction event.
-
-If the normal typology processing results in an alert, then review will be true. If EFRuP results in a different outcome to normal typology processing, then `review` will be `true` and this will enable a fraud analyst to review the result of the evaluation.
 
 **Note** The event flow rule processor result does not have a weight `wght` and will not be added to the typology score. 
  

--- a/Product/rule-processor-overview-rule-config.md
+++ b/Product/rule-processor-overview-rule-config.md
@@ -1,7 +1,0 @@
-<!-- SPDX-License-Identifier: Apache-2.0 -->
-
-![under construction](/images/construction.gif)
-
-In the meantime, you can view this content on Confluence:
-
-[https://frmscoe.atlassian.net/wiki/spaces/FRMS/pages/6586489/Rule+Processor+Overview#4.1.-Read-rule-config](https://frmscoe.atlassian.net/wiki/spaces/FRMS/pages/6586489/Rule+Processor+Overview#4.1.-Read-rule-config)

--- a/Product/rule-processor-overview.md
+++ b/Product/rule-processor-overview.md
@@ -25,6 +25,9 @@ The Event Director is responsible for determining which typologies are applicabl
 
 The rules receive the transaction, as well as the portion of the Network Map that was used to identify the rules as recipients (and by association also identifies which typologies are beneficiaries of the rule results).
 
+The event flow rule processor (EFRuP) is a special rule processor that operates differently from all the other rule processors that are described on this page.  Further information on EFRUP is available on the [Event Flow Processor Overview](/Product/event-flow-rule-processor.md) page.
+
+
 Each rule executes as a discrete and bespoke function in the evaluation process. It is a Tazama design principle that any given rule in the system has as small a purpose as possible and seeks to answer a single and very specific behavioral question about the transaction it is evaluation, for example:
 
  - How many transactions were made by the debtor?
@@ -39,7 +42,7 @@ Our reference rule is [Rule 901 - Number of transactions performed by the debtor
 
 ## The rule executer
 
-Individual rule processors are wrapped in a rule executer shell that handles common functions for all rule processors in a common way. While this makes rule processors easier to maintain by abstracting common code into the rule executer and leaving unique code in the rule processor, it does make the deployment process a little more complicated and onerous. In a production setting we would automate the deployment of the rule processors via Helm charts, but for our Docker Compose deployment, the process is a little more manual.
+Individual rule processors are wrapped in a rule executer shell that handles common functions for all rule processors in a common way. While this makes rule processors easier to maintain by abstracting common code into the rule executer and leaving unique code in the rule processor.
 
 ![rule-executer-design](../images/tazama-rule-executer.png)
 

--- a/Product/transaction-aggregation-and-decisioning-processor.md
+++ b/Product/transaction-aggregation-and-decisioning-processor.md
@@ -34,57 +34,30 @@ Where interdiction is required, either option 1 and 2 above is the most suitable
 
 The TADProc must retrieve the typology triggers from the Tazama configuration so that the TADProc can determine if any of the typologies results warrant an investigation.
 
-The typology triggers must define a specific threshold value linked to each of the typologies that defines the following workflow outcomes:
+##### 7.2 The typology configuration
 
-1. **Review**: If a typology score is equal to or greater than this value, the TADProc will trigger an alert to an adjacent Case Management System via egress API to initiate an investigation into the transaction.
-
-2. **None**: If a typology score is less than the Review threshold, no triggered action is taken by the TADProc.
-
-Additionally, if a transaction configuration for a transaction cannot be found, or is empty, no investigation will be triggered out of the transaction.
-
-##### 7.2 The transaction configuration
-
-The transaction configuration defines the typology alert thresholds for each of the typologies in the platform. The structure of the transaction configuration models that of the network map.
+The typology configuration defines the typology alert and interdiction thresholds for each of the typologies in the platform. 
 
 **Example**:
 
 ```json
-{
-    "messages": [
-        {
-            "id": "004@1.0.0",
-            "cfg": "1.0.0",
-            "txTp": "pacs.002.001.12",
-            {
-                "id": "001@1.0.0",
-                "cfg": "1.0.0",
-                "typologies": [
-                    {
-                        "id": "001@1.0.0",
-                        "cfg": "1.0.0",
-                        "threshold": 500
-                    },
-                    {
-                        "id": "216@1.0.0",
-                        "cfg": "1.0.0",
-                        "threshold": 400
-                    }
-                ]
-            }
-        }
-    ]
-}
+  "typology_name": "Rule-901-Typology-999",
+  "id": "typology-processor@1.0.0",
+  "cfg": "999@1.0.0",
+  "workflow": {
+    "alertThreshold": 200,
+    "interdictionThreshold": 400,
+    "flowProcessor": "EFRuP@1.0.0"
+  }
 ```
 
 #### 7.3 Check typology triggers
 
-If all typology results had been received, evaluate each typology against the transaction configuration to determine if an investigation is required. The outcomes of the evaluation depends on the typology score against the defined thresholds and may be to create (or update) an investigation case, or to do nothing.
-
-The evaluation outcome of a typology against its thresholds must be logged for each typology, i.e. that the typology was evaluated, what the threshold was, and what the determination was (Review, or None).
+If all typology results had been received, the typology processor evaluate each typology against the typology configuration to determine if an investigation is required. The outcomes of the evaluation depends on the typology score against the defined alertThreshold. If the typology score is equal to or greater than the alertThreshold, the typology processor sets the typology review flag to `true`.
 
 ##### 7.4 Create investigation case
 
-If the typology score is equal to or greater than the review threshold defined for the typology in the TADProc configuration, the TADProc will trigger a review message in JSON format to an adjacent Case Management System to flag the transaction for review.
+If any typology `review` flag is `true`, the TADProc will trigger a review message in JSON format to an adjacent Case Management System to flag the transaction for review.
 
 The outgoing alert message contains:
 
@@ -100,63 +73,57 @@ Sample output message:
 
 ```json
 {
-    "transaction": { ...
+  "transactionID": "d71103b09a4a47a987e4fa6d5f5497a7",
+  "transaction": {
+ ...
+  },
+  "networkMap": {
+...
+  },
+  "report": {
+    "evaluationID": "548ac93a-69e9-4acf-b804-85f7ff2c57db",
+    "metaData": {
+      "prcgTmDP": 12166572,
+      "prcgTmED": 236381
     },
-    "networkMap": { ...
-    },
-    "transactionResult": {
-        "resultId": "9f896062-41d4-4a66-8ecc-b16fc6146919",
-        "dateTime": "2021-12-09T11:13:06.000Z",
-        "id": "004@1.0.0",
-        "cfg": "1.0.0",
-        "status": "ALRT",
-        "description": "Alert triggered",
-        "typologyResults": [
+    "status": "ALRT",
+    "timestamp": "2025-01-17T08:15:10.433Z",
+    "tadpResult": {
+      "id": "004@1.0.0",
+      "cfg": "1.0.0",
+      "typologyResult": [
+        {
+          "id": "typology-processor@1.0.0",
+          "cfg": "999@1.0.0",
+          "result": 200,
+          "ruleResults": [
             {
-                "id": "001@1.0.0",
-                "cfg": "1.0.0",
-                "result": 700,
-                "threshold": 400,
-                "ruleResults": [
-                    {
-                        "id": "002@1.0.0",
-                        "cfg": "1.0.0",
-                        "subRuleRef": ".01",
-                        "wght": 100,
-                        "reason": "Debtor received < 10 transactions within the last 72 hours"
-                    },
-                    {
-                        "id": "016@1.0.0",
-                        "cfg": "1.0.0",
-                        "subRuleRef": ".01",
-                        "wght": 100,
-                        "reason": "Creditor received >= 10 transactions within the last 24 hours"
-                    },
-                    {
-                        "id": "018@1.0.0",
-                        "cfg": "1.0.0",
-                        "subRuleRef": ".01",
-                        "wght": 100,
-                        "reason": "Debtor transfered an amount >= the historical maximum threshold over the last 3 months"
-                    },
-                    {
-                        "id": "027@1.0.0",
-                        "cfg": "1.0.0",
-                        "subRuleRef": ".01",
-                        "wght": 100,
-                        "reason": "Immediate transaction mirorring detected for debtor account"
-                    },
-                    {
-                        "id": "045@1.0.0",
-                        "cfg": "1.0.0",
-                        "subRuleRef": ".01",
-                        "wght": 300,
-                        "reason": "First recorded successful and complete incoming transaction received by the creditor"
-                    }
-                ]
+              "id": "EFRuP@1.0.0",
+              "cfg": "none",
+              "subRuleRef": "none",
+              "prcgTm": 6052681,
+              "wght": 0
             },
-        ]
+            {
+              "id": "901@1.0.0",
+              "cfg": "1.0.0",
+              "subRuleRef": ".02",
+              "prcgTm": 17682366,
+              "wght": 200
+            }
+          ],
+          "prcgTm": 8754078,
+          "review": true,
+          "workflow": {
+            "alertThreshold": 200,
+            "interdictionThreshold": 400,
+            "flowProcessor": "EFRuP@1.0.0"
+          }
+        }
+      ],
+      "prcgTm": 6509701
     }
+  }
 }
 ```
 

--- a/Product/transaction-monitoring-service-api.md
+++ b/Product/transaction-monitoring-service-api.md
@@ -34,7 +34,7 @@ The TMS API implements ISO 20022 message formats to facilitate Payment Initiatio
 
 ISO20022 is traditionally an XML-based standard, but Tazama has implemented an abridged JSON message format to minimize the message payload to increase the performance and reduce bandwidth requirements.
 
-For more information on Tazama’s ISO 20022 implemented, see the [ISO20022 and Tazama](../Knowledge-Articles/iso20022-and-tazama.md) page.
+For more information on Tazama's ISO 20022 implemented, see the [ISO20022 and Tazama](../Knowledge-Articles/iso20022-and-tazama.md) page.
 
 The TMS API ingests transaction messages in real-time through the TMS API. The intention is to evaluate each transaction as they are performed, before they are sent to their destinations, to give Tazama an opportunity to evaluate the transaction before completion and to allow a transaction to be blocked.
 

--- a/Product/typology-processing.md
+++ b/Product/typology-processing.md
@@ -14,7 +14,6 @@
       - [5.5.1. The Typology Configuration](#551-the-typology-configuration)
   - [5.6. Calculate typology score](#56-calculate-typology-score)
   - [5.7. Submit typology results](#57-submit-typology-results)
-    - [Event flow processing](#event-flow-processing)
   - [5.8 A note on typology interdiction](#58-a-note-on-typology-interdiction)
 
 ## Introduction
@@ -43,7 +42,22 @@ Once each typology has been scored, the result of the typology will be passed to
 
 The rule processor passes its completed result to the Typology Processor.
 
-The rule result message includes the original transaction, the Network Sub-map and the rule execution result (Rule identifier, sub-rule identifier (for rule-sets), boolean rule result and result reason).
+The rule result message includes the original transaction, the Network Sub-map and the rule execution result 
+
+The rule result includes the rule identifier and the rule configuration, sub-rule identifier (`subruleref`), processing time for the rule and result score.
+
+**Rule result example**
+
+```JSON
+{
+    "id": "901@1.0.0",
+    "cfg": "1.0.0",
+    "subRuleRef": ".02",
+    "prcgTm": 17682366,
+    "wght": 200
+  }
+```
+**Note** The ERFuP rule does not generate a score and the `wght` will always be 0
 
 ### 5.1. Determine beneficiary typologies
 
@@ -69,43 +83,7 @@ If all of the rule results specified in the Network Sub-map for a specific typol
 
 If all of the rule results specified in the Network Sub-map for a specific typology have been received, the Typology Processor must retrieve the typology configuration for the beneficiary typology so that the rule results can be combined into a typology score.
 
-At present, the calculation of a typology score is a straight-forward logic expression:
-
-typology result = IF(rule_result_1.outcome THEN rule_result_1.score) + … IF(rule_result_n.outcome THEN rule_result_n.score)
-
-The individual rule result scores, as a mapped to a weighted number based on the rule's boolean outcome (TRUE or FALSE), is defined as part of the typology configuration. Once mapped to a numerical value, the typology score is calculated as the sum of all rule result values.
-
-typology score = rule_result_1.score + … + rule_result_n.score
-
-**For example**: In the following rule outcome table for rule 003:
-
-| **Sub-rule ref** | **Outcome** | **Typology Score Value** |
-| --- | --- | --- |
-| 003.00 | Payee account dormancy = FALSE | 0   |
-| 003.01 | Payee account dormancy 3 = TRUE | 33  |
-| 003.02 | Payee account dormancy 6 = TRUE | 67  |
-| 003.03 | Payee account dormancy 12 = TRUE | 100 |
-| 003.04 | Payee account dormancy = FALSE | 0   |
-
-In other words, if there had been no transfer requests from or to the account in 211 days (i.e. 003.02 = TRUE), the contribution of this rule (003) to the typology score would be 67 (can we call them rule points?)
-
-Only TRUE outcomes for a rule or sub-rule are expected to produce a score. FALSE outcomes are generally assumed to void a rule entirely and render a score of ZERO.
-
-The logic expression for typology 28 would be composed as follows:
-
-[IF(001.01 outcome THEN 001.01.score) + IF(001.02 outcome THEN 001.02.score) +
-
-IF(001.03 outcome THEN 001.03.score) + IF(001.04 outcome THEN 001.04.score) +
-
-IF(001.05 outcome THEN 001.05.score) + IF(001.06 outcome THEN 001.06.score)] +
-
-[IF(002.01 outcome THEN 002.01.score) + IF(002.02 outcome THEN 002.02.score) +
-
-IF(002.03 outcome THEN 002.03.score)] + … +
-
-IF(071.outcome THEN 071.score) +
-
-IF(078.outcome THEN 078.score)
+At present, the calculation of a typology score is a straight-forward logic expression: typology score = rule_result_1.score + … + rule_result_n.score
 
 <div style="text-align: right">
     <a href="#introduction">Top</a>
@@ -178,19 +156,15 @@ The event flow processor is a special processor that is defined differently in t
 
 For each beneficiary typology with a complete set of rule results, and using the typology expression and the associated score values, the Typology Processor must calculate the typology score for the typology.
 
+**Note** The ERFuP rule does not contribute to the typology score and the `wght` for EFRuP rule will always be 0.
+
 ### 5.7. Submit typology results
 
 Once the calculation of the typology score is complete, the Typology Processor must pass the typology result, including the transaction information, Network Sub-map, typology results and rule results to the Transaction Aggregation and Decisioning Processor.
 
-#### Event flow processing
-
-If a typology score is equal to or greater than the threshold value and there is an override in place, the Typology Processor will not trigger an interdiction workflow to instruct the client system to block the transaction event.
-
-If the normal typology processing results in an alert, then review will be true. If EFRuP results in a different outcome to normal typology processing, then `review` will be `true` and this will enable a fraud analyst to review the result of the evaluation.
-
 ### 5.8 A note on typology interdiction
 
-It makes sense for the typology processor to be able to interdict a transaction directly, if the threshold for interdiction has been met unless there is an override in place, in which case the Typology Processor will not trigger an interdiction.
+It makes sense for the typology processor to be able to interdict a transaction directly, if the threshold for interdiction has been met,s unless there is an override in place, in which case the Typology Processor will not trigger an interdiction.
 
 1. For a given typology, a specific threshold value must be linked to the typology for the following workflow outcomes:
     1. **Interdiction**: If a typology score is equal to or greater than this value, the Typology Processor will trigger an interdiction workflow to instruct the client system to block the transaction, unless there is an override in place, in which case the Typology Processor will not trigger an interdiction.

--- a/Product/typology-processing.md
+++ b/Product/typology-processing.md
@@ -164,7 +164,7 @@ Once the calculation of the typology score is complete, the Typology Processor m
 
 ### 5.8 A note on typology interdiction
 
-It makes sense for the typology processor to be able to interdict a transaction directly, if the threshold for interdiction has been met,s unless there is an override in place, in which case the Typology Processor will not trigger an interdiction.
+The typology processor will interdict a transaction directly if the threshold for interdiction has been met, unless there is an override in place in which case the typology processor will not trigger an interdiction.
 
 1. For a given typology, a specific threshold value must be linked to the typology for the following workflow outcomes:
     1. **Interdiction**: If a typology score is equal to or greater than this value, the Typology Processor will trigger an interdiction workflow to instruct the client system to block the transaction, unless there is an override in place, in which case the Typology Processor will not trigger an interdiction.

--- a/README.md
+++ b/README.md
@@ -2,11 +2,10 @@
 
 ![Tazama](/images/Tazama-logo-banner.png)
 
-# <a name='top'></a>Welcome to the Tazama Project!
+# <a name='top'></a>Welcome to the Tazama Project! <!-- omit in toc -->
 
 The sections below provide a brief overview of the Tazama system, with links to pages that contain more detailed information.
 
-- [Welcome to the Tazama Project!](#welcome-to-the-tazama-project)
 - [1.  What is Tazama](#1--what-is-tazama)
 - [2. Understanding typologies and rules](#2-understanding-typologies-and-rules)
 - [3. Core components](#3-core-components)
@@ -26,7 +25,7 @@ Tazama is designed to ingest transaction data in real-time through its Transacti
 
 Ingested transactions are stored in the Tazama database from where it will be used to support real-time modelling of participant behavior through a number of rule processors that will evaluate the transaction and its participants to look for suspicious behavior. Rule results will be summarized into fraud and money-laundering scenarios, called typologies.
 
-If the rules and typologies show sufficient evidence of suspicious behavior, an investigation alert will be issued to an external case management system and in extreme cases, the transaction can also be blocked to prevent the transfer of funds.
+If the rules and typologies show sufficient evidence of suspicious behavior, an investigation alert will be issued to an external case management system and in extreme cases, the transaction can also be blocked to prevent the transfer of funds. Through the event flow (EFRuP) feature it is possible to configure the system to override the blocking of transactions under certain conditions.  The EFRuP also enables operational control to be configured in the form of non-overridable blocks and overrideable blocks specified for an entity or account.
 
 In the following pages, we intend to give you a clear understanding of the Tazama Transaction Monitoring System, and how all the components of the system work together to detect fraud and money laundering.
 
@@ -44,7 +43,7 @@ By assessing the transfer to the fraudsters, it is possible to identify more hig
 
 If the Fraudster recipient was the customer being monitored it is likely they will receive the funds, and quickly move it to the next person in their money laundering chain. This would be captured in a Layering Typology which would include age of the account or dormant account suddenly becoming active instead of age of the participant.
 
-In the creation of a typology, it is worth highlighting that our phishing example can also create a false positive when a grandparent sends a large sum for an important life event to one of their grandchildren. Previously gifts had been sent via the parents and as such no historical financial relationship had been established. It is for this reason that a rule such as “allow-list of sender and receiver pairs” can be implemented. The typology will then assess if this transaction can be progressed because it is approved in the override request. It is worth noting that a diligent fraudster would look to circumnavigate this control by sending a small transaction that would be allowed, and then moving larger amounts once the history had been established. It is therefore important that an understanding of the customers in a given FSP is developed, as finding the balance of low false positives and managing the activity of fraudsters “testing the boundaries” are critical to the success of an implementation.
+In the creation of a typology, it is worth highlighting that our phishing example can also create a false positive when a grandparent sends a large sum for an important life event to one of their grandchildren. Previously gifts had been sent via the parents and as such no historical financial relationship had been established. It is for this reason that a rule such as 'allow-list of sender and receiver pairs' can be implemented. The typology will then assess if this transaction can be progressed because it is approved in the override request. It is worth noting that a diligent fraudster would look to circumnavigate this control by sending a small transaction that would be allowed, and then moving larger amounts once the history had been established. It is therefore important that an understanding of the customers in a given FSP is developed, as finding the balance of low false positives and managing the activity of fraudsters 'testing the boundaries' are critical to the success of an implementation.
 
 <div style="text-align: right"><a href="#top">Top</a></div>
 
@@ -91,11 +90,11 @@ A rule processor is designed to address a singular scenario, but its output migh
 
 A rule can be used to assess more than one outcome, such as age bands if needed, as the same source data is used as the only variable in the calculation.
 
-Rule processors are templated so that logging, data input, determined outcomes, data output and telemetry are consistently applied by all rule processors. It is just the specific rule’s logic, including the queries that retrieve transaction history according to the rule requirements, that changes between rules. Rules must be developed individually, but the parameters used in the calculation of a rule and its outcomes are contained in a configuration file. The rule behavior can be configured independent of the rule code, reducing the operational burden for modifying a rule to a mere configuration process.
+Rule processors are templated so that logging, data input, determined outcomes, data output and telemetry are consistently applied by all rule processors. It is just the specific rule's logic, including the queries that retrieve transaction history according to the rule requirements, that changes between rules. Rules must be developed individually, but the parameters used in the calculation of a rule and its outcomes are contained in a configuration file. The rule behavior can be configured independent of the rule code, reducing the operational burden for modifying a rule to a mere configuration process.
 
-The event flow rule processor (EFRuP) is a specialised rule processor that enables the system to exert operational control over evaluations based on the outcome of business processes and prior evaluations. The system is able to block or override a transaction event based on the evaluation of conditions against one of the transaction event attributes.
+The event flow rule processor (EFRuP) is a specialised rule processor that enables the system to exert operational control over evaluations based on the outcome of business processes and prior evaluations. The system is able to block or override a transaction event based on the evaluation of conditions against one of the transaction event attributes. Further information on EFRUP is available on the [Event Flow Processor Overview](/Product/event-flow-rule-processor.md) page.
 
-Once the rule has completed its evaluation, the output is forwarded to the Typology Processor.
+Once the rule processor has completed its evaluation, the output is forwarded to the Typology Processor.
 
 Further information on the role of the Rules Processor is available on the [Rule Processor Overview](/Product/rule-processor-overview.md) page.
 
@@ -103,7 +102,7 @@ Further information on the role of the Rules Processor is available on the [Rule
 
 ## 3.4. Typology Processor
 
-The typology processor is designed to aggregate and assess the outcomes from the all rules within the scope of a specific typology. The scope of a typology is defined in a typology configuration specific to each typology. The typology processor scores the combined effect of a typology's rules to determine if the weighted aggregation of the rule outcomes has reached a predefined threshold for raising a fraud or money laundering alert. Each rule's weighted contribution to the typology score, as well as the scoring predicate, or formula, is also defined in the typology configuration.
+The typology processor is designed to aggregate and assess the outcomes from the all rules within the scope of a specific typology. The scope of a typology is defined in a typology configuration specific to each typology. The typology processor scores the combined effect of a typology's rules to determine if the aggregation of the rule outcomes has reached a predefined threshold for raising a fraud or money laundering alert. Each rule's contribution to the typology score, as well as the scoring predicate, or formula, is also defined in the typology configuration.
 
 Returning to our earlier example of a phishing scam where rules are implemented to assess an elderly person, sending a large amount of funds to a new payee (or creditor). The three rules being assessed in this example are:
 
@@ -118,6 +117,8 @@ If a suspicious transaction is identified, there are a number of actions that ca
  - **High** - the transaction can be interdicted (blocked) immediately, with an alert sent to the FSP transacting and/or case management systems;
  - **Moderate** - an investigation alert to a case management systems can be created once the evaluation of all the typologies are complete;
  - **Low** - the transaction will pass without intervention, but the evaluation outcome will be stored for future retrieval.
+
+The typology score is evaluated against an 'interdiction' threshold to determine if the client system should be instructed to block a transaction 'in flight'. The Event Flow processor can be configured to override the interdiction outcome for a typology for a specific account or entity. 
 
 Further information on the role of the Typology Processor is available on the [Typology Processing](/Product/typology-processing.md) page.
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ By assessing the transfer to the fraudsters, it is possible to identify more hig
 
 If the Fraudster recipient was the customer being monitored it is likely they will receive the funds, and quickly move it to the next person in their money laundering chain. This would be captured in a Layering Typology which would include age of the account or dormant account suddenly becoming active instead of age of the participant.
 
-In the creation of a typology, it is worth highlighting that our phishing example can also create a false positive when a grandparent sends a large sum for an important life event to one of their grandchildren. Previously gifts had been sent via the parents and as such no historical financial relationship had been established. It is important that an understanding of the customers in a given FSP is developed, as finding the balance of low false positives and managing the activity of fraudsters 'testing the boundaries' are critical to the success of an implementation.
+In the creation of a typology, it is worth highlighting that our phishing example can also create a false positive when a grandparent sends a large sum for an important life event to one of their grandchildren. Previously gifts had been sent via the parents and as such no historical financial relationship had been established. It is important that an understanding of the customers in a given FSP is developed, as finding the balance of low false positives and managing the activity of fraudsters "testing the boundaries" are critical to the success of an implementation.
 
 <div style="text-align: right"><a href="#top">Top</a></div>
 
@@ -118,7 +118,7 @@ If a suspicious transaction is identified, there are a number of actions that ca
  - **Moderate** - an investigation alert to a case management systems can be created once the evaluation of all the typologies are complete;
  - **Low** - the transaction will pass without intervention, but the evaluation outcome will be stored for future retrieval.
 
-The typology score is evaluated against an 'interdiction' threshold to determine if the client system should be instructed to block a transaction 'in flight'. The Event Flow rule processor can be configured to override the interdiction outcome for a typology for a specific account or entity. 
+The typology score is evaluated against an "interdiction" threshold to determine if the client system should be instructed to block a transaction "in flight". The Event Flow rule processor can be configured to override the interdiction outcome for a typology for a specific account or entity. 
 
 Further information on the role of the Typology Processor is available on the [Typology Processing](/Product/typology-processing.md) page.
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ By assessing the transfer to the fraudsters, it is possible to identify more hig
 
 If the Fraudster recipient was the customer being monitored it is likely they will receive the funds, and quickly move it to the next person in their money laundering chain. This would be captured in a Layering Typology which would include age of the account or dormant account suddenly becoming active instead of age of the participant.
 
-In the creation of a typology, it is worth highlighting that our phishing example can also create a false positive when a grandparent sends a large sum for an important life event to one of their grandchildren. Previously gifts had been sent via the parents and as such no historical financial relationship had been established. It is for this reason that a rule such as 'allow-list of sender and receiver pairs' can be implemented. The typology will then assess if this transaction can be progressed because it is approved in the override request. It is worth noting that a diligent fraudster would look to circumnavigate this control by sending a small transaction that would be allowed, and then moving larger amounts once the history had been established. It is therefore important that an understanding of the customers in a given FSP is developed, as finding the balance of low false positives and managing the activity of fraudsters 'testing the boundaries' are critical to the success of an implementation.
+In the creation of a typology, it is worth highlighting that our phishing example can also create a false positive when a grandparent sends a large sum for an important life event to one of their grandchildren. Previously gifts had been sent via the parents and as such no historical financial relationship had been established. It is important that an understanding of the customers in a given FSP is developed, as finding the balance of low false positives and managing the activity of fraudsters 'testing the boundaries' are critical to the success of an implementation.
 
 <div style="text-align: right"><a href="#top">Top</a></div>
 
@@ -92,7 +92,7 @@ A rule can be used to assess more than one outcome, such as age bands if needed,
 
 Rule processors are templated so that logging, data input, determined outcomes, data output and telemetry are consistently applied by all rule processors. It is just the specific rule's logic, including the queries that retrieve transaction history according to the rule requirements, that changes between rules. Rules must be developed individually, but the parameters used in the calculation of a rule and its outcomes are contained in a configuration file. The rule behavior can be configured independent of the rule code, reducing the operational burden for modifying a rule to a mere configuration process.
 
-The event flow rule processor (EFRuP) is a specialised rule processor that enables the system to exert operational control over evaluations based on the outcome of business processes and prior evaluations. The system is able to block or override a transaction event based on the evaluation of conditions against one of the transaction event attributes. Further information on EFRUP is available on the [Event Flow Processor Overview](/Product/event-flow-rule-processor.md) page.
+The event flow rule processor (EFRuP) is a specialised rule processor that enables the system to exert operational control over evaluations based on the outcome of business processes and prior evaluations. The system is able to block or override a transaction event based on the evaluation of conditions against one of the transaction event attributes. Further information on EFRuP is available on the [Event Flow Rule Processor Overview](/Product/event-flow-rule-processor.md) page.
 
 Once the rule processor has completed its evaluation, the output is forwarded to the Typology Processor.
 
@@ -118,7 +118,7 @@ If a suspicious transaction is identified, there are a number of actions that ca
  - **Moderate** - an investigation alert to a case management systems can be created once the evaluation of all the typologies are complete;
  - **Low** - the transaction will pass without intervention, but the evaluation outcome will be stored for future retrieval.
 
-The typology score is evaluated against an 'interdiction' threshold to determine if the client system should be instructed to block a transaction 'in flight'. The Event Flow processor can be configured to override the interdiction outcome for a typology for a specific account or entity. 
+The typology score is evaluated against an 'interdiction' threshold to determine if the client system should be instructed to block a transaction 'in flight'. The Event Flow rule processor can be configured to override the interdiction outcome for a typology for a specific account or entity. 
 
 Further information on the role of the Typology Processor is available on the [Typology Processing](/Product/typology-processing.md) page.
 


### PR DESCRIPTION
# SPDX-License-Identifier: Apache-2.0

## What did we change?

Updated product docs for EFRuP change
Update to TADP outdated content

## Why are we doing this?

Refresh documentation for the latest version of the system

## How was it tested?
- [x] Locally
- [ ] Development Environment
- [ ] Not needed, changes very basic
- [ ] Husky successfully run
- [ ] Unit tests passing and Documentation done