### PR TITLE
docs: add licensing.md doc

### DIFF
--- a/Guides/licensing.md
+++ b/Guides/licensing.md
@@ -1,0 +1,55 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
+## Licensing <!-- omit in toc -->
+
+## Table of Contents <!-- omit in toc -->
+
+- [Overview](#overview)
+- [License Information](#license-information)
+- [SPDX License Header](#SPDX-License-Header)
+- [Developer Certificate of Origin (DCO)](#Developer-Certificate-of-Origin-(DCO))
+- [Contributing](#contributing)
+
+## Overview
+
+This project is licensed under the Apache License, Version 2.0 (Apache-2.0). This allows for open collaboration while ensuring that all contributions and modifications are properly licensed under an open-source standard.
+
+## License Information
+
+All source code within this repository is subject to the Apache-2.0 license. By contributing, you agree that your contributions fall under this license.
+
+A copy of the full Apache-2.0 license is available in the LICENSE file in the root of this repository. For more details, visit Apache License 2.0.
+
+## SPDX License Header
+
+Each file in this repository must include the following SPDX license header at the top:
+
+```
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+```
+
+This ensures consistency and compliance with licensing requirements across all project files.
+
+## Developer Certificate of Origin (DCO)
+
+We require all contributors to sign off their Git commits using the Developer Certificate of Origin (DCO). This means that every commit message must include the following line:
+
+```
+Signed-off-by: Your Name <your.email@example.com>
+```
+
+By signing off, you certify that you have the right to contribute the changes under the project's license. The DCO ensures that all contributions are made with proper legal authorization and transparency.
+
+## Contributing
+
+Before making a contribution, please:
+
+- Ensure your changes include the SPDX license header.
+
+- Sign off all your commits following the DCO requirements.
+
+- Read the CONTRIBUTING.md guide for more details on the contribution process.
+
+- If you have any questions about licensing or contribution requirements, feel free to open an issue or reach out to the maintainers.
+
+Thank you for contributing!


### PR DESCRIPTION
# SPDX-License-Identifier: Apache-2.0

## What did we change?
Add a `licensing.md` file.

## Why are we doing this?
It's required as part of the contribution guide structuring.

## How was it tested?
- [ ] Locally
- [ ] Development Environment
- [x] Not needed, changes very basic
- [ ] Husky successfully run
- [ ] Unit tests passing and Documentation done