### PR TITLE
docs: add links to set up verified commits

### DIFF
--- a/Guides/committing-changes.md
+++ b/Guides/committing-changes.md
@@ -2,6 +2,8 @@
 
 # Committing Your Changes
 
+### Commit message standard
+
 When committing changes to your development branch you would be required to submit a commit message to describe the change. Depending on the mechanism that you are using to commit your changes, you may have access to a commit message as well as an extended description of your changes, but it is expected that you should complete at least the commit message.
 
 Tazama aims to comply with the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification for adding human and machine-readable meaning to commit messages (subject to the commit types recommended below).
@@ -42,6 +44,10 @@ Scope keywords are tailored to Tazama's specific requirements. Tazama's source c
 
  - If your change is limited to a single repository, the scope should be the name of the repository, e.g. `typology-processor` or `rule-executer`.
  - If your change impacts multiple repositories, the scope should be `multi-repo`.
+
+### Verified commits
+
+See [guide for setting up verified commits](https://github.com/tazama-lf/docs/blob/dev/Knowledge-Articles/Setup-Verified-Commits-On-Github.md)
 
 ## Further reading
 


### PR DESCRIPTION
# SPDX-License-Identifier: Apache-2.0

## What did we change?

- added link to set up verified commits from the commit guide

## Why are we doing this?

- improved navigation and accessibility

## How was it tested?
- [ ] Locally
- [ ] Development Environment
- [ ] Not needed, changes very basic
- [ ] Husky successfully run
- [ ] Unit tests passing and Documentation done