### PR TITLE
docs: Update single-ubuntu-server-full-service-full-stack-docker-tazama-guide.md

### DIFF
--- a/Guides/single-ubuntu-server-full-service-full-stack-docker-tazama.md
+++ b/Guides/single-ubuntu-server-full-service-full-stack-docker-tazama.md
@@ -164,7 +164,7 @@ Any terminal: `./start.sh`
 The one docker-compose command that is equivalent to running the start.sh script without any prompts is;
 
 ```
-docker compose -p tazama -f docker-compose.yaml -f docker-compose.override.yaml -f docker-compose.db.yaml -f docker-compose.full.yaml -f docker-compose.relay.yaml -f docker-compose.dev.ui.yaml up -d
+docker-compose -p tazama -f docker-compose.yaml -f docker-compose.override.yaml -f docker-compose.db.yaml -f docker-compose.full.yaml -f docker-compose.relay.yaml -f docker-compose.dev.ui.yaml -f docker-compose.dev.nats-utils.yaml up -d
 ```
 
 **Output:**
@@ -214,6 +214,8 @@ Now that these two repositories are cloned, we can perform the following Newman 
 newman run collection-file -e environment-file --timeout-request 10200
 ```
 
+The command will be in most cases `newman run tms-configuration/default/tms-config.postman_collection.json -e postman/environments/Tazama-Docker-Compose-LOCAL.postman_environment.json --timeout-request 10200`
+
  - The `collection-file` is the full path to the location on your local machine where the `tms-configuration/default/tms-config.postman_collection.json` file is located.
  - The `environment-file` is the full path to the location on your local machine where the `postman/environments/Tazama-Docker-Compose-LOCAL.postman_environment.json` file is located.
  - If the path contains spaces, wrap the string in double-quotes.
@@ -252,6 +254,8 @@ You should be able to submit a test transaction to the Transaction Monitoring Se
 ```
 newman run collection-file -e environment-file --timeout-request 10200 --delay-request 500
 ```
+
+The command will be in most cases `newman run tms-configuration/default/tms-config-test.postman_collection.json -e postman/environments/Tazama-Docker-Compose-LOCAL.postman_environment.json --timeout-request 10200 --delay-request 500`
 
  - The `collection-file` is the full path to the location on your local machine where the `tms-configuration/default/tms-config-test.postman_collection.json` file is located.
  - The `environment-file` is the full path to the location on your local machine where the `postman/environments/Tazama-Docker-Compose-LOCAL.postman_environment.json` file is located.


### PR DESCRIPTION
# SPDX-License-Identifier: Apache-2.0

## What did we change?
Update single ubuntu server full service full stack docker tazama guide

## Why are we doing this?
Docs maintenance

## How was it tested?
- [x] Locally
- [x] Development Environment
- [ ] Not needed, changes very basic
- [ ] Husky successfully run
- [ ] Unit tests passing and Documentation done