### PR TITLE
docs: link to contribution guide updated

### DIFF
--- a/Community/Tazama-Code-of-Conduct.md
+++ b/Community/Tazama-Code-of-Conduct.md
@@ -1,4 +1,4 @@
 <!-- SPDX-License-Identifier: Apache-2.0 -->
-
-[Code of conduct link](https://github.com/frmscoe/.github/blob/main/CODE_OF_CONDUCT.md)
+ 
+[Code of conduct link](https://github.com/tazama-lf/.github/blob/main/CODE_OF_CONDUCT.md)
 

--- a/Community/Tazama-Contribution-Guide.md
+++ b/Community/Tazama-Contribution-Guide.md
@@ -2,4 +2,4 @@
 
 # Contribution Guide
 
-[Contributing document link](https://github.com/frmscoe/.github/blob/main/CONTRIBUTING.md)
+[Contributing document link](https://github.com/tazama-lf/.github/blob/main/CONTRIBUTING.md)


### PR DESCRIPTION
# SPDX-License-Identifier: Apache-2.0

## What did we change?
 - Changed the contribution guide link from frmscoe to tazama-lf org

## Why are we doing this?
- tazama-lf is the primary public org 

## How was it tested?
- [ ] Locally
- [ ] Development Environment
- [ ] Not needed, changes very basic
- [ ] Husky successfully run
- [ ] Unit tests passing and Documentation done

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Code of Conduct reference to direct community members to current governance documentation
  * Updated Contribution Guide reference to provide access to latest contribution standards
  * These updates ensure consistency with project resources and support effective community engagement

<!-- end of auto-generated comment: release notes by coderabbit.ai -->