### PR TITLE
feat: added deployment guides

### DIFF
--- a/Technical/Deployment-Guides/CMS-Deployment-Guide.md
+++ b/Technical/Deployment-Guides/CMS-Deployment-Guide.md
@@ -1,0 +1,78 @@
+# Tazama Case Management System (CMS) - Deployment Guide
+
+## Part 1 – Setting up
+
+1. Clone the repository:
+
+```bash
+git clone https://github.com/tazama-lf/case-management-system.git
+```
+
+2. Move into the backend directory:
+
+```bash
+cd backend
+```
+
+3. Add `GH_TOKEN` to the backend `.npmrc`.
+
+---
+
+## Part 2 - Running CMS through Docker Compose
+
+1. While in the backend directory, create the `.env` file by renaming `.env.example` to `.env`:
+
+```bash
+mv .env.example .env
+```
+
+For the frontend:
+
+```bash
+mv .env.template .env
+```
+
+Set the following frontend environment variables:
+
+```env
+VITE_API_BASE_URL=http://localhost:3000
+VITE_VOILA_BASE_URL=http://localhost:8866
+```
+
+2. Run `docker-compose-infra.yaml` to set up the database, Valkey, and NATS microservices:
+
+```bash
+docker compose -f docker-compose-infra.yaml up -d
+```
+
+3. Once the infrastructure is ready and running, run CMS:
+
+```bash
+docker compose -f docker-compose-cms.yaml up -d
+```
+
+---
+
+## Part 3 - Running with Full Stack Docker Tazama
+
+1. Use the Full Stack Docker Tazama environment variables in the `.env` file of the CMS service:
+
+```env
+CONFIGURATION_DATABASE_URL=postgresql://postgres:unused@tazama-postgres-1:5432/encrichment
+REDIS_HOST=tazama-valkey-1
+SERVER_URL=nats://tazama-nats-1:4222
+```
+
+2. Run CMS assuming Full Stack Docker Tazama is already running. CMS will use the `tazama_default` network because the compose file uses `external: true`.
+
+```bash
+docker compose -f docker-compose-cms.yaml up -d
+```
+
+---
+
+## Debug Commands
+
+```bash
+docker logs -f cms-backend
+```

--- a/Technical/Deployment-Guides/CMS-Deployment-Guide.md
+++ b/Technical/Deployment-Guides/CMS-Deployment-Guide.md
@@ -58,7 +58,7 @@ docker compose -f docker-compose-cms.yaml up -d
 1. Use the Full Stack Docker Tazama environment variables in the `.env` file of the CMS service:
 
 ```env
-CONFIGURATION_DATABASE_URL=postgresql://postgres:unused@tazama-postgres-1:5432/encrichment
+CONFIGURATION_DATABASE_URL=postgresql://postgres:unused@tazama-postgres-1:5432/enrichment
 REDIS_HOST=tazama-valkey-1
 SERVER_URL=nats://tazama-nats-1:4222
 ```

--- a/Technical/Deployment-Guides/DEAPI-Deployment-Guide.md
+++ b/Technical/Deployment-Guides/DEAPI-Deployment-Guide.md
@@ -61,4 +61,4 @@ AUTH_URL=tazama-auth-1
 
 Debug Commands
 
-docker logs -f data-enrichment-service
+docker logs -f tazama-deapi

--- a/Technical/Deployment-Guides/DEAPI-Deployment-Guide.md
+++ b/Technical/Deployment-Guides/DEAPI-Deployment-Guide.md
@@ -1,0 +1,71 @@
+# Data Enrichment Service - Deployment Guide
+
+Data Enrichment Service - Deployment Guide
+
+
+## Part 1 – Setting up:
+
+
+1.  Clone the repository: git clone https://github.com/tazama-lf/data-enrichment-service
+
+2. Add GH_TOKEN in .npmrc
+
+3. Set up Database, Redis and NATS through compose file:
+
+docker compose up -d
+
+4. Build the docker image: 
+docker build -t data-enrichment-service:latest
+
+
+## Part 2 - Running Data Enrichment Service:
+
+
+1. Create .env file through editing the .env.template file by renaming or use command: 
+mv .env.template .env
+
+2. Confirm the use of localhost for all the required microservices to run data enrichment service.
+
+```env
+CONFIGURATION_DATABASE_URL=postgresql://postgres:postgres@localhost:5432/enrichment
+```
+
+```env
+REDIS_HOST=localhost
+```
+
+```env
+SERVER_URL=nats://localhost:4222
+```
+
+3. Run the service through docker container by using the command through terminal: 
+- docker run -d -p 3001:3001 –-name tazama-deapi –-env-file .env data-enrichment-service:latest
+
+
+## Part 3 - Running with Full Stack Docker Tazama:
+
+
+1. Use Full Stack Docker Tazama environment variables in the .env file of the data enrichment service.
+
+```env
+CONFIGURATION_DATABASE_URL=postgresql://postgres:unused@tazama-postgres-1:5432/encrichment
+```
+
+```env
+REDIS_HOST=tazama-valkey-1
+```
+
+```env
+SERVER_URL=nats://tazama-nats-1:4222
+```
+
+```env
+AUTH_URL=tazama-auth-1
+```
+
+2. Run docker images through command and network: 
+docker run -d -p 3001:3001 --name tazama-deapi --env-file .env --network tazama_default data-enrichment-service:latest
+
+Debug Commands
+
+docker logs -f data-enrichment-service

--- a/Technical/Deployment-Guides/DEAPI-Deployment-Guide.md
+++ b/Technical/Deployment-Guides/DEAPI-Deployment-Guide.md
@@ -1,28 +1,22 @@
 # Data Enrichment Service - Deployment Guide
 
-Data Enrichment Service - Deployment Guide
-
-
 ## Part 1 – Setting up:
-
 
 1.  Clone the repository: git clone https://github.com/tazama-lf/data-enrichment-service
 
-2. Add GH_TOKEN in .npmrc
+2.  Add GH_TOKEN in .npmrc
 
-3. Set up Database, Redis and NATS through compose file:
+3.  Set up Database, Redis and NATS through compose file:
 
 docker compose up -d
 
-4. Build the docker image: 
-docker build -t data-enrichment-service:latest
-
+4. Build the docker image:
+   docker build -t data-enrichment-service:latest .
 
 ## Part 2 - Running Data Enrichment Service:
 
-
-1. Create .env file through editing the .env.template file by renaming or use command: 
-mv .env.template .env
+1. Create .env file through editing the .env.template file by renaming or use command:
+   mv .env.template .env
 
 2. Confirm the use of localhost for all the required microservices to run data enrichment service.
 
@@ -38,17 +32,16 @@ REDIS_HOST=localhost
 SERVER_URL=nats://localhost:4222
 ```
 
-3. Run the service through docker container by using the command through terminal: 
-- docker run -d -p 3001:3001 –-name tazama-deapi –-env-file .env data-enrichment-service:latest
+3. Run the service through docker container by using the command through terminal:
 
+- docker run -d -p 3001:3001 --name tazama-deapi –-env-file .env data-enrichment-service:latest
 
 ## Part 3 - Running with Full Stack Docker Tazama:
-
 
 1. Use Full Stack Docker Tazama environment variables in the .env file of the data enrichment service.
 
 ```env
-CONFIGURATION_DATABASE_URL=postgresql://postgres:unused@tazama-postgres-1:5432/encrichment
+CONFIGURATION_DATABASE_URL=postgresql://postgres:unused@tazama-postgres-1:5432/enrichment
 ```
 
 ```env
@@ -63,8 +56,8 @@ SERVER_URL=nats://tazama-nats-1:4222
 AUTH_URL=tazama-auth-1
 ```
 
-2. Run docker images through command and network: 
-docker run -d -p 3001:3001 --name tazama-deapi --env-file .env --network tazama_default data-enrichment-service:latest
+2. Run docker images through command and network:
+   docker run -d -p 3001:3001 --name tazama-deapi --env-file .env --network tazama_default data-enrichment-service:latest
 
 Debug Commands
 

--- a/Technical/Deployment-Guides/DEMS-Deployment-Guide.md
+++ b/Technical/Deployment-Guides/DEMS-Deployment-Guide.md
@@ -1,25 +1,19 @@
 # Dynamic Event Monitoring Service - Deployment Guide
 
-Dynamic Event Monitoring Service - Deployment Guide
-
-
 ## Part 1 – Setting up:
-
 
 1.  Clone the repository: git clone https://github.com/tazama-lf/event-monitoring-service.git
 
-2. Add GH_TOKEN in .npmrc
+2.  Add GH_TOKEN in .npmrc
 
-3. Build the docker image:
+3.  Build the docker image:
 
-docker build -t tazama-dems:latest
-
+docker build -t tazama-dems:latest .
 
 ## Part 2 - Running DEMS:
 
-
-1. Create .env file through editing the .env.template file by renaming or use command: 
-mv .env.template .env
+1. Create .env file through editing the .env.template file by renaming or use command:
+   mv .env.template .env
 
 2. Confirm the use of localhost for all the required microservices to run dynamic event monitoring service.
 
@@ -35,17 +29,16 @@ REDIS_HOST=localhost
 SERVER_URL=nats://localhost:4222
 ```
 
-3. Run the service through docker container by using the command through terminal: 
-- docker run -d -p 3002:3002 –-name tazama-dems –-env-file .env tazama-dems:latest
+3. Run the service through docker container by using the command through terminal:
 
+- docker run -d -p 3002:3002 --name tazama-dems –-env-file .env tazama-dems:latest
 
 ## Part 3 - Running with Full Stack Docker Tazama:
-
 
 1. Use Full Stack Docker Tazama environment variables in the .env file of the dynamic event monitoring service.
 
 ```env
-CONFIGURATION_DATABASE_URL=postgresql://postgres:unused@tazama-postgres-1:5432/encrichment
+CONFIGURATION_DATABASE_URL=postgresql://postgres:unused@tazama-postgres-1:5432/enrichment
 ```
 
 ```env
@@ -56,8 +49,8 @@ REDIS_HOST=tazama-valkey-1
 SERVER_URL=nats://tazama-nats-1:4222
 ```
 
-2. Run docker images through command and network: 
-docker run -d -p 3002:3002 --name tazama-dems --env-file .env --network tazama_default tazama-dems:latest
+2. Run docker images through command and network:
+   docker run -d -p 3002:3002 --name tazama-dems --env-file .env --network tazama_default tazama-dems:latest
 
 Debug Commands
 

--- a/Technical/Deployment-Guides/DEMS-Deployment-Guide.md
+++ b/Technical/Deployment-Guides/DEMS-Deployment-Guide.md
@@ -1,0 +1,64 @@
+# Dynamic Event Monitoring Service - Deployment Guide
+
+Dynamic Event Monitoring Service - Deployment Guide
+
+
+## Part 1 – Setting up:
+
+
+1.  Clone the repository: git clone https://github.com/tazama-lf/event-monitoring-service.git
+
+2. Add GH_TOKEN in .npmrc
+
+3. Build the docker image:
+
+docker build -t tazama-dems:latest
+
+
+## Part 2 - Running DEMS:
+
+
+1. Create .env file through editing the .env.template file by renaming or use command: 
+mv .env.template .env
+
+2. Confirm the use of localhost for all the required microservices to run dynamic event monitoring service.
+
+```env
+CONFIGURATION_DATABASE_URL=postgresql://postgres:postgres@localhost:5432/configuration
+```
+
+```env
+REDIS_HOST=localhost
+```
+
+```env
+SERVER_URL=nats://localhost:4222
+```
+
+3. Run the service through docker container by using the command through terminal: 
+- docker run -d -p 3002:3002 –-name tazama-dems –-env-file .env tazama-dems:latest
+
+
+## Part 3 - Running with Full Stack Docker Tazama:
+
+
+1. Use Full Stack Docker Tazama environment variables in the .env file of the dynamic event monitoring service.
+
+```env
+CONFIGURATION_DATABASE_URL=postgresql://postgres:unused@tazama-postgres-1:5432/encrichment
+```
+
+```env
+REDIS_HOST=tazama-valkey-1
+```
+
+```env
+SERVER_URL=nats://tazama-nats-1:4222
+```
+
+2. Run docker images through command and network: 
+docker run -d -p 3002:3002 --name tazama-dems --env-file .env --network tazama_default tazama-dems:latest
+
+Debug Commands
+
+docker logs -f tazama-dems

--- a/Technical/Deployment-Guides/TCS-Deployment-Guide.md
+++ b/Technical/Deployment-Guides/TCS-Deployment-Guide.md
@@ -1,0 +1,69 @@
+# Tazama Connection Studio(TCS) - Deployment Guide
+
+Tazama Connection Studio(TCS) - Deployment Guide
+
+
+## Part 1 – Setting up:
+
+
+1.  Clone the repository: git clone https://github.com/tazama-lf/connection-studio.git
+
+2. cd /backend & cd /frontend
+
+3. Add GH_TOKEN of the backend .npmrc
+
+
+## Part 2 - Running TCS through Docker Compose:
+
+
+1. While being in the backend directory, create .env file through editing the .env.example file by renaming to .env or use command:
+
+mv .env.example .env
+
+Add ADMIN_SERVICE_URL, AUTH_URL and OPENSEARCH env’s.
+
+Frontend:
+
+mv .env.template .env
+
+```env
+VITE_API_BASE_URL=http://localhost:3010
+```
+
+```env
+VITE_DATA_ENRICHMENT_SERVICE_URL=http://localhost:3002
+```
+
+2. Run the docker-compose-infra.yaml to set up Database, Valkey and NATS microservices.
+
+docker compose -f docker-compose-infra.yaml up -d
+
+3. Once, the infrastructure is ready and running, run the compose command to run Connection Studio:
+
+docker compose -f docker-compose-tcs.yaml up -d
+
+
+## Part 3 - Running with Full Stack Docker Tazama:
+
+
+1. Use Full Stack Docker Tazama environment variables in the .env file of the tcs service.
+
+```env
+CONFIGURATION_DATABASE_URL=postgresql://postgres:unused@tazama-postgres-1:5432/encrichment
+```
+
+```env
+REDIS_HOST=tazama-valkey-1
+```
+
+```env
+SERVER_URL=nats://tazama-nats-1:4222
+```
+
+2. Run docker compose command to run TCS assuming Full Stack Docker Tazama already running. TCS will be using the tazama_default network as the compose file consists of external: true
+
+docker compose -f docker-compose-tcs.yaml up -d
+
+Debug Commands
+
+docker logs -f connection-studio-backend

--- a/Technical/Deployment-Guides/TCS-Deployment-Guide.md
+++ b/Technical/Deployment-Guides/TCS-Deployment-Guide.md
@@ -1,20 +1,14 @@
 # Tazama Connection Studio(TCS) - Deployment Guide
 
-Tazama Connection Studio(TCS) - Deployment Guide
-
-
 ## Part 1 – Setting up:
-
 
 1.  Clone the repository: git clone https://github.com/tazama-lf/connection-studio.git
 
-2. cd /backend & cd /frontend
+2.  cd backend & cd frontend
 
-3. Add GH_TOKEN of the backend .npmrc
-
+3.  Add GH_TOKEN to the backend .npmrc
 
 ## Part 2 - Running TCS through Docker Compose:
-
 
 1. While being in the backend directory, create .env file through editing the .env.example file by renaming to .env or use command:
 
@@ -42,14 +36,12 @@ docker compose -f docker-compose-infra.yaml up -d
 
 docker compose -f docker-compose-tcs.yaml up -d
 
-
 ## Part 3 - Running with Full Stack Docker Tazama:
-
 
 1. Use Full Stack Docker Tazama environment variables in the .env file of the tcs service.
 
 ```env
-CONFIGURATION_DATABASE_URL=postgresql://postgres:unused@tazama-postgres-1:5432/encrichment
+CONFIGURATION_DATABASE_URL=postgresql://postgres:unused@tazama-postgres-1:5432/enrichment
 ```
 
 ```env

--- a/Technical/Deployment-Guides/TRS-Deployment-Guide.md
+++ b/Technical/Deployment-Guides/TRS-Deployment-Guide.md
@@ -1,0 +1,81 @@
+# Tazama Rule Studio (TRS) - Deployment Guide
+
+Tazama Rule Studio (TRS) - Deployment Guide
+
+
+## Part 1 – Setting up:
+
+
+1.  Clone the repository: git clone https://github.com/tazama-lf/rule-studio.git
+
+2. cd /backend & cd /frontend
+
+3. Add GH_TOKEN of the backend .npmrc
+
+
+## Part 2 - Running TRS through Docker Compose:
+
+
+1. While being in the backend directory, create .env file through editing the .env.example file by renaming to .env or use command:
+
+mv .env.example .env
+
+Add TAZAMA_AUTH_URL, ADMIN_SERVICE_URL and OPENSEARCH envs.
+
+Frontend:
+
+mv .env.template .env
+
+```env
+VITE_API_BASE_URL=http://localhost:3005
+```
+
+```env
+VITE_SANDBOX_API_URL=simulation-sandbox-url
+```
+
+```env
+VITE_NATS_API_URL=nats-utilities-url
+```
+
+```env
+VITE_SIMULATION_ENDPOINT=tms-url
+```
+
+2. Run the docker-compose.yaml to run TRS backend and Frontend along with Database, Valkey and NATS.
+
+docker compose up -d
+
+
+## Part 3 - Running with Full Stack Docker Tazama:
+
+
+1. Use Full Stack Docker Tazama environment variables in the .env file of the trs service.
+
+```env
+ADMIN_SERVICE_URL=http://tazama-admin-service-1:3100
+```
+
+```env
+TAZAMA_AUTH_URL=http://tazama-auth-1:3020/v1/auth
+```
+
+For Backend run:
+
+cd /backend
+
+docker build -t trs-backend:latest .
+
+docker run -d -p 3005:3005 --env-file /backend/.env --name trs-backend --network tazama_default trs-backend:latest
+
+For Frontend run:
+
+cd /frontend
+
+docker build -t trs-frontend:latest .
+
+docker run -d -p 5174:5174 --env-file /frontend/.env --name trs-frontend --network tazama_default trs-frontend:latest
+
+Debug Commands
+
+docker logs -f trs-backend

--- a/Technical/Deployment-Guides/TRS-Deployment-Guide.md
+++ b/Technical/Deployment-Guides/TRS-Deployment-Guide.md
@@ -1,20 +1,14 @@
 # Tazama Rule Studio (TRS) - Deployment Guide
 
-Tazama Rule Studio (TRS) - Deployment Guide
-
-
 ## Part 1 – Setting up:
-
 
 1.  Clone the repository: git clone https://github.com/tazama-lf/rule-studio.git
 
-2. cd /backend & cd /frontend
+2.  cd backend & cd frontend
 
-3. Add GH_TOKEN of the backend .npmrc
-
+3.  Add GH_TOKEN to the backend .npmrc
 
 ## Part 2 - Running TRS through Docker Compose:
-
 
 1. While being in the backend directory, create .env file through editing the .env.example file by renaming to .env or use command:
 
@@ -46,9 +40,7 @@ VITE_SIMULATION_ENDPOINT=tms-url
 
 docker compose up -d
 
-
 ## Part 3 - Running with Full Stack Docker Tazama:
-
 
 1. Use Full Stack Docker Tazama environment variables in the .env file of the trs service.
 

--- a/Technical/Deployment-Guides/TRS-Deployment-Guide.md
+++ b/Technical/Deployment-Guides/TRS-Deployment-Guide.md
@@ -54,7 +54,7 @@ TAZAMA_AUTH_URL=http://tazama-auth-1:3020/v1/auth
 
 For Backend run:
 
-cd /backend
+cd backend
 
 docker build -t trs-backend:latest .
 
@@ -62,7 +62,7 @@ docker run -d -p 3005:3005 --env-file /backend/.env --name trs-backend --network
 
 For Frontend run:
 
-cd /frontend
+cd ../frontend
 
 docker build -t trs-frontend:latest .
 


### PR DESCRIPTION
# SPDX-License-Identifier: Apache-2.0

## What did we change?
Added deployment guides for TRS, TCS, DEAPI, CMS, and DEMS.

## Why are we doing this?
To provide clear deployment instructions for each component in the Tazama system.

## How was it tested?
- [x] Locally
- [x] Development Environment
- [ ] Not needed, changes very basic
- [x] Husky successfully run
- [x] Unit tests passing and Documentation done

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added deployment guides for five Tazama components (Case Management, Data Enrichment, Dynamic Event Monitoring, Connection Studio, Rule Studio). Each guide covers repository setup, environment configuration, Docker-based deployment options for standalone and full-stack setups, example build/run commands, service connectivity examples, and basic debug/log streaming instructions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->