### PR TITLE
docs: add working group guideline doc

### DIFF
--- a/Community/Tazama-TSC-Working-Group-Governance.md
+++ b/Community/Tazama-TSC-Working-Group-Governance.md
@@ -1,0 +1,47 @@
+# Tazama Technical Steering Committee
+## Working Group Governance Guidelines
+This document serves to govern the operation of a Technical Steering Committee Working Group from inception to conclusion.
+## Glossary of terms
+
+| Term | Description |
+|---|---|
+| TSC | (Tazama) Technical Steering Committee |
+| WG | (Tazama TSC) Working Group |
+
+## 1. Requirements to constitute an official working group (WG) of the TSC
+
+A Working Group must be mandated by the TSC as an active Working Group, with the following specific requirements:
+1. A Working Group must be constituted in terms of TSC responsibilities in terms of the Tazama Technical Charter section 2, paragraph (g)(iv)
+2. A Working Group must be formally approved as a Working Group by the TSC before proceeding with its work
+3. The TSC will issue each Working Group with a unique reference number in the format TSCWG9999 to uniquely identify the working group for reporting and operational purposes
+4. A new “discussion” must be created in the Tazama-project repository on the Tazama GitHub to host the Working Group
+5. The Working Group must be named to concisely describe what the working group aims to accomplish
+    1. The name must not violate the Tazama Code of Conduct
+    2. The name must describe the objectives or focus area for the Working Group
+6. Active Working Groups should report back to the TSC at every TSC meeting unless otherwise directed by the TSC
+7. The Working group must have clearly defined objectives and outcomes
+8. Objectives and outcomes must be ratified by the TSC, either when the formation of the Working Group is discussed in the TSC, or, if the objective of the Working Group is to define its objectives and outcomes, at the first TSC meeting following the first Working Group meeting.
+9. Working Group objectives and outcomes must be aligned to the goals and objectives of Tazama as enshrined in the Tazama Technical Charter, Values, Design Principles and as agreed within the TSC from time to time.
+10. Working Group objectives must further the objectives of the TSC and product related goals
+11. Working Groups must abide by all TSC governance standards, including, but not limited to, the Technical Charter and the Tazama Code of Conduct
+12. The TSC must maintain an inventory of all active Working Groups
+13. The TSC must review the status of a Working Group at each TSC meeting and determine the status of the Working Group (Active or Closed).
+    1. The TSC will attempt to assist Working Groups that are stalled to address the cause of delays, if possible, or to determine that the Working Group should be closed.
+    2. The TSC may close a Working Group if the outcomes are no longer required or desired, or if the continued prospect of success or participation is unlikely.
+
+## 2. Participation
+1. A Working Group must have at least 2 active contributors from different organizations.
+2. A Working Group workshop without the required number of contributors must be rescheduled.
+3. A Working Group that is unable to muster the required number of participants must report to the TSC to either assist in recruiting additional contributors or dissolve the Working Group.
+4. A Working Group’s first task must be for the participants to appoint a Working Group Lead
+
+## 3. Working Group Lead - expectations / responsibilities
+1. The Working Group Lead is responsible for the delivery of the Working Group objectives
+2. The Lead should command the required technical skill to meet the objectives of the WG
+3. The Lead must be familiar with the Tazama ecosystem
+4. The Lead must fulfill the administrative requirements with respect to the Working Group:
+Schedule regular meetings
+   1. Ensure all meetings of the Working Group are minuted, either in or linked from the Tazama-project discussion group for the Working Group.
+   2. Maintain an attendance register of each Working Group meeting as part of the minutes
+   3. Report on the Working Group’s progress in terms of its objectives to the TSC
+   4. Track issues related to the Working Group in the Tazama-project discussion group for the Working Group


### PR DESCRIPTION
## Summary

Adds the Tazama TSC Working Group Governance document to the Community folder.

## Changes

- `Community/Tazama-TSC-Working-Group-Governance.md` - new working group guideline document

## DCO

Signed-off-by: Justus-at-Tazama <jortlepp@contractor.linuxfoundation.org>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Tazama Technical Steering Committee Working Group Governance document providing comprehensive guidelines for establishing and managing working groups, including formal requirements, participation rules, glossary, and Working Group Lead responsibilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->