### PR TITLE
feat: simulation studio deployment guide and rule studio updated deployment guide

### DIFF
--- a/Technical/Deployment-Guides/DEAPI-Deployment-Guide.md
+++ b/Technical/Deployment-Guides/DEAPI-Deployment-Guide.md
@@ -2,7 +2,7 @@
 
 ## Part 1 – Setting up:
 
-1.  Clone the repository: git clone https://github.com/tazama-lf/data-enrichment-service
+1.  Clone the repository: git clone https://github.com/tazama-lf/data-enrichment-service.git
 
 2.  Add GH_TOKEN in .npmrc
 

--- a/Technical/Deployment-Guides/SS-Deployment-Guide.md
+++ b/Technical/Deployment-Guides/SS-Deployment-Guide.md
@@ -44,6 +44,15 @@ Add TAZAMA_AUTH_URL, ADMIN_SERVICE_URL, SIMULATION_SANDBOX_URL and OPENSEARCH en
 
 For Simulation Studio specifically, also add TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE, TESTCONTAINERS_HOST_OVERRIDE, and TESTCONTAINERS_RYUK_DISABLED envs. Optionally add DEBUG=testcontainers* to surface testcontainers debug logs in the Rule Studio logs, which is useful when troubleshooting testcontainers issues.
 
+Simulation Studio pulls rule images (and currently the nats-utilities container) from a DockerHub registry, so the backend needs DockerHub credentials and access to a Docker socket:
+
+```env
+DOCKERHUB_USERNAME=<dockerhub-username>
+DOCKERHUB_NAMESPACE=<dockerhub-namespace>
+DOCKERHUB_TOKEN=<dockerhub-access-token>
+DOCKER_HOST=unix:///var/run/docker.sock
+```
+
 Frontend:
 
 mv .env.template .env

--- a/Technical/Deployment-Guides/SS-Deployment-Guide.md
+++ b/Technical/Deployment-Guides/SS-Deployment-Guide.md
@@ -1,0 +1,101 @@
+# Simulation Studio (SS) - Deployment Guide
+
+Simulation Studio is not a separate service - it is part of the Rule Studio service. This guide therefore covers the Rule Studio deployment steps, with notes on the Simulation Studio specific setup you will need to do.
+
+## Part 1 – Setting up:
+
+1.  Clone the repository: git clone https://github.com/tazama-lf/rule-studio.git
+
+2.  cd backend & cd frontend
+
+3.  Add GH_TOKEN to the backend .npmrc
+
+4.  For running simulations, you may need to change the default address pools used by your Docker engine. Each simulation runs in its own Docker network, so this setting dictates how many simulations you can run simultaneously. Each network needs at least 128 addresses (size 25), and you will want enough pool space to support a large number of concurrent networks.
+
+Here is a suggested daemon.json that provides up to 65,536 networks of 128 addresses each, drawn from the 10.128.0.0/9 range:
+
+```json
+{
+  "default-address-pools": [
+    { "base": "10.128.0.0/9", "size": 25 }
+  ]
+}
+```
+
+If you need to draw from multiple private ranges (for example, to avoid conflicts with existing 10.x routes), you can combine pools:
+
+```json
+{
+  "default-address-pools": [
+    { "base": "10.128.0.0/9", "size": 25 },
+    { "base": "172.16.0.0/12", "size": 25 },
+    { "base": "192.168.0.0/16", "size": 25 }
+  ]
+}
+```
+
+## Part 2 - Running Rule Studio through Docker Compose:
+
+1. While being in the backend directory, create .env file through editing the .env.example file by renaming to .env or use command:
+
+mv .env.example .env
+
+Add TAZAMA_AUTH_URL, ADMIN_SERVICE_URL, SIMULATION_SANDBOX_URL and OPENSEARCH envs.
+
+For Simulation Studio specifically, also add TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE, TESTCONTAINERS_HOST_OVERRIDE, and TESTCONTAINERS_RYUK_DISABLED envs. Optionally add DEBUG=testcontainers* to surface testcontainers debug logs in the Rule Studio logs, which is useful when troubleshooting testcontainers issues.
+
+Frontend:
+
+mv .env.template .env
+
+```env
+VITE_API_BASE_URL=http://localhost:3005
+```
+
+```env
+VITE_SANDBOX_API_URL=simulation-sandbox-url
+```
+
+```env
+VITE_NATS_API_URL=nats-utilities-url
+```
+
+```env
+VITE_SIMULATION_ENDPOINT=tms-url
+```
+
+2. Run the docker-compose.yaml to run Rule Studio backend and Frontend along with Database, Valkey and NATS.
+
+docker compose up -d
+
+## Part 3 - Running with Full Stack Docker Tazama:
+
+1. Use Full Stack Docker Tazama environment variables in the .env file of the rule-studio service.
+
+```env
+ADMIN_SERVICE_URL=http://tazama-admin-service-1:3100
+```
+
+```env
+TAZAMA_AUTH_URL=http://tazama-auth-1:3020/v1/auth
+```
+
+For Backend run:
+
+cd backend
+
+docker build -t trs-backend:latest .
+
+docker run -d -p 3005:3005 --env-file /backend/.env --name trs-backend --network tazama_default trs-backend:latest
+
+For Frontend run:
+
+cd ../frontend
+
+docker build -t trs-frontend:latest .
+
+docker run -d -p 5174:5174 --env-file /frontend/.env --name trs-frontend --network tazama_default trs-frontend:latest
+
+Debug Commands
+
+docker logs -f trs-backend

--- a/Technical/Deployment-Guides/TRS-Deployment-Guide.md
+++ b/Technical/Deployment-Guides/TRS-Deployment-Guide.md
@@ -14,27 +14,69 @@
 
 mv .env.example .env
 
-Add TAZAMA_AUTH_URL, ADMIN_SERVICE_URL and OPENSEARCH envs.
+Set the following backend environment variables:
+
+```env
+NODE_ENV=dev
+MAX_CPU=2
+FUNCTION_NAME=model-management-backend
+PORT=3005
+TAZAMA_AUTH_URL=http://<auth-host>:3020/v1/auth
+AUTH_PUBLIC_KEY_PATH=/path/to/public.pem
+CERT_PATH_PUBLIC=/path/to/public.pem
+ADMIN_SERVICE_URL=http://<admin-host>:3100
+ALLOWED_ORIGINS=<frontend-host>:5174
+CRYPTO_SECRET_KEY=<shared-crypto-key>
+ENCRYPTION_KEY=<shared-encryption-key>
+IV_LENGTH=<16-char-iv>
+AUDIT_PROVIDER=opensearch
+OPENSEARCH_NODE=http://<opensearch-host>:9200
+OPENSEARCH_USERNAME=admin
+OPENSEARCH_PASSWORD=admin
+OPENSEARCH_INDEX=rule-studio-audit
+REDIS_HOST=<valkey-host>
+REDIS_PORT=6379
+REDIS_PASSWORD=<redis-password>
+```
+
+CRYPTO_SECRET_KEY and ENCRYPTION_KEY are shared with the frontend (see VITE_CRYPTO_KEY below) — the same values must be set on both sides for payload encryption to work.
+
+Rule images are published to a DockerHub registry when rules are built, so the backend needs DockerHub credentials and access to a Docker socket:
+
+```env
+DOCKERHUB_USERNAME=<dockerhub-username>
+DOCKERHUB_NAMESPACE=<dockerhub-namespace>
+DOCKERHUB_TOKEN=<dockerhub-access-token>
+DOCKER_HOST=unix:///var/run/docker.sock
+```
+
+The backend also uses testcontainers to spin up isolated environments for rule simulations. Set the following so testcontainers can reach the host Docker daemon:
+
+```env
+TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE=/var/run/docker.sock
+TESTCONTAINERS_HOST_OVERRIDE=host.docker.internal
+TESTCONTAINERS_RYUK_DISABLED=true
+```
+
+Optionally add `DEBUG=testcontainers*` to surface testcontainers debug logs in the Rule Studio logs, which is useful when troubleshooting testcontainers issues.
 
 Frontend:
 
 mv .env.template .env
 
 ```env
-VITE_API_BASE_URL=http://localhost:3005
+VITE_API_URL=http://<backend-host>:3005
+VITE_SANDBOX_API_URL=http://<sandbox-host>:3050
+VITE_NATS_API_URL=http://<nats-utilities-host>:4000
+VITE_DEMS_ENDPOINT=http://<dems-host>:3002/dems-engine
+VITE_ADMIN_ENDPOINT=http://<admin-host>:3100
+VITE_SIMULATION_ENDPOINT=http://<tms-host>:5000/v1/evaluate/iso20022/pacs.002.001.12
+VITE_CRYPTO_KEY=<shared-crypto-key>
+VITE_APP_NAME="Model Management"
+VITE_APP_VERSION=0.0.1
 ```
 
-```env
-VITE_SANDBOX_API_URL=simulation-sandbox-url
-```
-
-```env
-VITE_NATS_API_URL=nats-utilities-url
-```
-
-```env
-VITE_SIMULATION_ENDPOINT=tms-url
-```
+VITE_CRYPTO_KEY must match the backend's CRYPTO_SECRET_KEY / ENCRYPTION_KEY values.
 
 2. Run the docker-compose.yaml to run TRS backend and Frontend along with Database, Valkey and NATS.
 


### PR DESCRIPTION
# SPDX-License-Identifier: Apache-2.0

## What did we change?

- Added `Technical/Deployment-Guides/SS-Deployment-Guide.md`, a new
  deployment guide for Simulation Studio. The guide clarifies that
  Simulation Studio is part of the Rule Studio service and walks
  through Docker Compose and Full Stack Docker Tazama deployment
  paths, with SS-specific notes on testcontainers env vars, Docker
  daemon `default-address-pools` sizing for running many simulation
  networks concurrently, and the DockerHub registry credentials
  needed to pull rule images and the nats-utilities container.

- Expanded `Technical/Deployment-Guides/TRS-Deployment-Guide.md`
  with the complete backend and frontend environment variable sets
  used in actual deployments (OpenSearch audit config, Redis/Valkey,
  shared crypto/encryption key contract between backend and
  frontend, testcontainers, and DockerHub publishing credentials).

- Fixed a clone URL typo in
  `Technical/Deployment-Guides/DEAPI-Deployment-Guide.md`
  (`data-enrichment-service` → `data-enrichment-service.git`).

## Why are we doing this?

The existing deployment guides did not cover Simulation Studio as it is
a new expansion within Rule Studio, and the TRS guide was missing 
most of the environment variables required for a working deployment 
— including the DockerHub credentials now needed because rule 
images are published to a DockerHub registry on build and pulled 
from there at simulation time. These updates bring the docs in line with
 how TRS and SS are actually deployed today, so operators can stand up
the services without having to reverse-engineer the env config.

## How was it tested?
- [ ] Locally
- [ ] Development Environment
- [x] Not needed, changes very basic
- [ ] Husky successfully run
- [ ] Unit tests passing and Documentation done
